### PR TITLE
Add moderation, command, commerce, and intent workers

### DIFF
--- a/__main__.py
+++ b/__main__.py
@@ -1,8 +1,78 @@
-"""CLI entry point for the GroupMe posting workflow."""
+"""CLI entry point for GroupMe workflows."""
 from __future__ import annotations
 
-from app import bots
-from workers import run_posting_workflow
+import asyncio
+import os
+from typing import Mapping
+
+from app import GroupMe, bots
+from workers import (
+    CommandPlan,
+    CommercePlan,
+    IntentPlan,
+    ModerationPlan,
+    run_command_workflow,
+    run_commerce_workflow,
+    run_intent_detection_workflow,
+    run_moderation_workflow,
+    run_posting_workflow,
+)
+
+
+async def dispatch_message(
+    groupme: GroupMe,
+    *,
+    group_id: str,
+    user_id: str,
+    message_text: str,
+    command_store: Mapping[str, str] | None = None,
+) -> None:
+    """Route an incoming message through intent detection and downstream workers."""
+    intent_report = await run_intent_detection_workflow(IntentPlan(message_text=message_text))
+
+    if intent_report.intent == "commerce":
+        await run_commerce_workflow(
+            groupme,
+            CommercePlan(group_id=group_id, user_id=user_id, message_text=message_text),
+        )
+    elif intent_report.intent == "moderation":
+        await run_moderation_workflow(
+            groupme,
+            ModerationPlan(group_id=group_id, user_id=user_id, message_text=message_text),
+        )
+    elif intent_report.intent == "command":
+        await run_command_workflow(
+            groupme,
+            CommandPlan(
+                group_id=group_id,
+                message_text=message_text,
+                command_store=command_store or {},
+            ),
+        )
+
+
+def _build_groupme_client() -> GroupMe:
+    """Construct a GroupMe API client using environment configuration."""
+    token = os.environ.get("GROUPME_TOKEN", "")
+    if not token:
+        raise RuntimeError("GROUPME_TOKEN environment variable must be set.")
+    return GroupMe(token)
+
+
+async def _run_webhook_loop() -> None:
+    """Placeholder for webhook-driven processing that dispatches incoming messages."""
+    groupme = _build_groupme_client()
+    try:
+        # TODO: Replace with webhook listener integration.
+        await dispatch_message(
+            groupme,
+            group_id="demo-group",
+            user_id="demo-user",
+            message_text="/help",
+            command_store={"/help": "Available commands: /help, /catalog"},
+        )
+    finally:
+        await groupme.close()
 
 
 def main() -> None:
@@ -14,3 +84,4 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
+    # asyncio.run(_run_webhook_loop())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+"""Pytest configuration for path setup."""
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_workers_commands.py
+++ b/tests/test_workers_commands.py
@@ -1,0 +1,30 @@
+"""Tests for the custom command worker."""
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import asyncio
+
+from ..workers.commands import CommandPlan, run_command_workflow
+
+
+def test_run_command_workflow_posts_known_command():
+    command_store = {"/weather": "Expect sunshine all day."}
+    groupme = SimpleNamespace(messages=SimpleNamespace(post_to_group=AsyncMock()))
+    plan = CommandPlan(group_id="group-7", message_text="/weather", command_store=command_store)
+
+    asyncio.run(run_command_workflow(groupme, plan))
+
+    groupme.messages.post_to_group.assert_awaited()
+    kwargs = groupme.messages.post_to_group.await_args.kwargs
+    assert kwargs["group_id"] == "group-7"
+    assert "sunshine" in kwargs["text"].lower()
+
+
+def test_run_command_workflow_ignores_unknown_command():
+    command_store = {"/weather": "Expect sunshine all day."}
+    groupme = SimpleNamespace(messages=SimpleNamespace(post_to_group=AsyncMock()))
+    plan = CommandPlan(group_id="group-7", message_text="/unknown", command_store=command_store)
+
+    asyncio.run(run_command_workflow(groupme, plan))
+
+    groupme.messages.post_to_group.assert_not_awaited()

--- a/tests/test_workers_commerce.py
+++ b/tests/test_workers_commerce.py
@@ -1,0 +1,32 @@
+"""Tests for the commerce worker."""
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import asyncio
+
+from ..workers.commerce import CommercePlan, run_commerce_workflow
+
+
+def test_run_commerce_workflow_sends_catalog():
+    groupme = SimpleNamespace(messages=SimpleNamespace(post_to_group=AsyncMock()))
+    plan = CommercePlan(group_id="group-9", user_id="user-9", message_text="@gort show me the catalog")
+
+    report = asyncio.run(run_commerce_workflow(groupme, plan))
+
+    groupme.messages.post_to_group.assert_awaited()
+    kwargs = groupme.messages.post_to_group.await_args.kwargs
+    assert kwargs["group_id"] == "group-9"
+    assert "catalog" in kwargs["text"].lower()
+    assert report.action == "catalog_sent"
+
+
+def test_run_commerce_workflow_confirms_purchase():
+    groupme = SimpleNamespace(messages=SimpleNamespace(post_to_group=AsyncMock()))
+    plan = CommercePlan(group_id="group-9", user_id="user-9", message_text="@gort buy sunglasses")
+
+    report = asyncio.run(run_commerce_workflow(groupme, plan))
+
+    groupme.messages.post_to_group.assert_awaited()
+    kwargs = groupme.messages.post_to_group.await_args.kwargs
+    assert "confirmed" in kwargs["text"].lower()
+    assert report.action == "order_confirmed"

--- a/tests/test_workers_intent_detector.py
+++ b/tests/test_workers_intent_detector.py
@@ -1,0 +1,21 @@
+"""Tests for the intent detection worker."""
+import asyncio
+
+from ..workers.intent_detector import IntentPlan, run_intent_detection_workflow
+
+
+def test_run_intent_detection_workflow_detects_commerce_intent():
+    plan = IntentPlan(message_text="I want to buy a gift")
+
+    report = asyncio.run(run_intent_detection_workflow(plan))
+
+    assert report.intent == "commerce"
+    assert report.confidence > 0.5
+
+
+def test_run_intent_detection_workflow_defaults_to_chitchat():
+    plan = IntentPlan(message_text="How was your day?")
+
+    report = asyncio.run(run_intent_detection_workflow(plan))
+
+    assert report.intent == "chitchat"

--- a/tests/test_workers_moderation.py
+++ b/tests/test_workers_moderation.py
@@ -1,0 +1,33 @@
+"""Tests for the moderation worker."""
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import asyncio
+
+from ..workers.moderation import ModerationPlan, run_moderation_workflow
+
+
+def test_run_moderation_workflow_warns_on_violation():
+    groupme = SimpleNamespace(messages=SimpleNamespace(post_to_group=AsyncMock()))
+    plan = ModerationPlan(
+        group_id="group-1",
+        user_id="user-42",
+        message_text="This is blatant spam content",
+    )
+
+    asyncio.run(run_moderation_workflow(groupme, plan))
+
+    assert groupme.messages.post_to_group.await_count == 1
+    kwargs = groupme.messages.post_to_group.await_args.kwargs
+    assert kwargs["group_id"] == "group-1"
+    assert "warning" in kwargs["text"].lower()
+    assert "user-42" in kwargs["text"]
+
+
+def test_run_moderation_workflow_no_action_for_clean_message():
+    groupme = SimpleNamespace(messages=SimpleNamespace(post_to_group=AsyncMock()))
+    plan = ModerationPlan(group_id="group-1", user_id="user-42", message_text="Hope you are well!")
+
+    asyncio.run(run_moderation_workflow(groupme, plan))
+
+    groupme.messages.post_to_group.assert_not_awaited()

--- a/workers/__init__.py
+++ b/workers/__init__.py
@@ -1,5 +1,33 @@
-"""Worker package for background posting workflows."""
+"""Worker package for background workflows."""
+from __future__ import annotations
 
-from .posting import run_posting_workflow
+from importlib import import_module
+from typing import Any
 
-__all__ = ["run_posting_workflow"]
+from .commands import CommandPlan, run_command_workflow
+from .commerce import CommercePlan, CommerceReport, run_commerce_workflow
+from .intent_detector import IntentPlan, IntentReport, run_intent_detection_workflow
+from .moderation import ModerationPlan, ModerationReport, run_moderation_workflow
+
+__all__ = [
+    "CommandPlan",
+    "CommercePlan",
+    "CommerceReport",
+    "IntentPlan",
+    "IntentReport",
+    "ModerationPlan",
+    "ModerationReport",
+    "run_command_workflow",
+    "run_commerce_workflow",
+    "run_intent_detection_workflow",
+    "run_moderation_workflow",
+    "run_posting_workflow",
+]
+
+
+def __getattr__(name: str) -> Any:
+    if name == "run_posting_workflow":
+        module = import_module("workers.posting")
+        return getattr(module, name)
+    raise AttributeError(name)
+

--- a/workers/commands.py
+++ b/workers/commands.py
@@ -1,0 +1,44 @@
+"""Worker for processing custom commands."""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Mapping
+from uuid import uuid4
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class CommandPlan:
+    """Plan for processing a potential command."""
+
+    group_id: str
+    message_text: str
+    command_store: Mapping[str, str] = field(default_factory=dict)
+    prefix: str = "/"
+
+
+async def run_command_workflow(groupme: Any, plan: CommandPlan) -> None:
+    """Execute the custom command workflow."""
+    logger.info("Checking for commands in group %s", plan.group_id)
+    message = plan.message_text.strip()
+    if not message or not message.startswith(plan.prefix):
+        logger.debug("Message does not start with prefix '%s'; ignoring.", plan.prefix)
+        return
+
+    trigger = message.split(maxsplit=1)[0].lower()
+    logger.debug("Extracted trigger '%s'", trigger)
+
+    normalized_store = {key.lower(): value for key, value in plan.command_store.items()}
+    response = normalized_store.get(trigger)
+    if response is None:
+        logger.debug("No stored command found for trigger '%s'", trigger)
+        return
+
+    logger.info("Found custom command for trigger '%s'; posting response.", trigger)
+    await groupme.messages.post_to_group(
+        group_id=plan.group_id,
+        source_guid=str(uuid4()),
+        text=response,
+    )

--- a/workers/commerce.py
+++ b/workers/commerce.py
@@ -1,0 +1,78 @@
+"""Worker for handling commerce flows."""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Optional
+from uuid import uuid4
+
+logger = logging.getLogger(__name__)
+
+MOCK_PRODUCT = {
+    "name": "GORT Smart Shades",
+    "description": "Adaptive tint sunglasses with voice assistant integration.",
+    "price": "$199",
+}
+
+
+@dataclass(slots=True)
+class CommercePlan:
+    """Plan for a commerce-related action."""
+
+    group_id: str
+    user_id: str
+    message_text: str
+
+
+@dataclass(slots=True)
+class CommerceReport:
+    """Report describing the outcome of the commerce workflow."""
+
+    action: str
+    message: Optional[str]
+
+
+def _build_catalog_message() -> str:
+    """Create a mock catalog message for prototype flows."""
+    return (
+        "Today's catalog:\n"
+        f"• {MOCK_PRODUCT['name']} — {MOCK_PRODUCT['price']}\n"
+        f"  {MOCK_PRODUCT['description']}"
+    )
+
+
+def _build_confirmation_message(user_id: str) -> str:
+    """Create a mock order confirmation message."""
+    return (
+        f"Order confirmed for {user_id}! {MOCK_PRODUCT['name']} is on its way. "
+        "You'll receive ACP updates shortly."
+    )
+
+
+async def run_commerce_workflow(groupme: Any, plan: CommercePlan) -> CommerceReport:
+    """Execute a commerce workflow based on user intent."""
+    logger.info("Handling commerce intent for user %s", plan.user_id)
+    message = plan.message_text.lower()
+
+    if "catalog" in message:
+        catalog_message = _build_catalog_message()
+        logger.debug("Sending catalog to group %s", plan.group_id)
+        await groupme.messages.post_to_group(
+            group_id=plan.group_id,
+            source_guid=str(uuid4()),
+            text=catalog_message,
+        )
+        return CommerceReport(action="catalog_sent", message=catalog_message)
+
+    if "buy" in message or "purchase" in message:
+        confirmation = _build_confirmation_message(plan.user_id)
+        logger.debug("Confirming order for user %s", plan.user_id)
+        await groupme.messages.post_to_group(
+            group_id=plan.group_id,
+            source_guid=str(uuid4()),
+            text=confirmation,
+        )
+        return CommerceReport(action="order_confirmed", message=confirmation)
+
+    logger.debug("No commerce action detected for message: %s", plan.message_text)
+    return CommerceReport(action="no_action", message=None)

--- a/workers/intent_detector.py
+++ b/workers/intent_detector.py
@@ -1,0 +1,47 @@
+"""Worker for detecting intent from messages."""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+KEYWORD_INTENTS: dict[str, tuple[str, ...]] = {
+    "commerce": ("buy", "purchase", "order", "catalog"),
+    "moderation": ("spam", "report", "abuse", "ban"),
+    "command": ("/", "!"),
+}
+
+
+@dataclass(slots=True)
+class IntentPlan:
+    """Plan for detecting intent from a message."""
+
+    message_text: str
+
+
+@dataclass(slots=True)
+class IntentReport:
+    """Report containing the detected intent."""
+
+    intent: str
+    confidence: float
+
+
+def _classify_intent(message_text: str) -> IntentReport:
+    lowered = message_text.lower()
+    for intent, keywords in KEYWORD_INTENTS.items():
+        if any(keyword in lowered for keyword in keywords):
+            logger.debug("Detected intent '%s' for message: %s", intent, message_text)
+            return IntentReport(intent=intent, confidence=0.9)
+    logger.debug("Defaulting to chitchat intent for message: %s", message_text)
+    return IntentReport(intent="chitchat", confidence=0.4)
+
+
+async def run_intent_detection_workflow(plan: IntentPlan) -> IntentReport:
+    """Analyze a message and return a detected intent."""
+    logger.info("Detecting intent for incoming message")
+    if not plan.message_text.strip():
+        logger.debug("Empty message detected; returning low-confidence chitchat.")
+        return IntentReport(intent="chitchat", confidence=0.1)
+    return _classify_intent(plan.message_text)

--- a/workers/moderation.py
+++ b/workers/moderation.py
@@ -1,0 +1,71 @@
+"""Worker for handling message moderation."""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Iterable, Optional
+from uuid import uuid4
+
+logger = logging.getLogger(__name__)
+
+VIOLATION_KEYWORDS: tuple[str, ...] = (
+    "spam",
+    "scam",
+    "offensive",
+    "abuse",
+)
+
+
+@dataclass(slots=True)
+class ModerationPlan:
+    """Plan for processing a single message for moderation."""
+
+    group_id: str
+    user_id: str
+    message_text: str
+
+
+@dataclass(slots=True)
+class ModerationReport:
+    """Summary of actions taken during moderation."""
+
+    action: Optional[str]
+    severity: float
+    notes: Optional[str] = None
+
+
+def _detect_violation(message_text: str, keywords: Iterable[str]) -> bool:
+    """Return True when the message contains one of the violation keywords."""
+    lowered = message_text.lower()
+    return any(keyword in lowered for keyword in keywords)
+
+
+async def run_moderation_workflow(groupme: Any, plan: ModerationPlan) -> ModerationReport:
+    """Execute the moderation workflow for a given message."""
+    logger.info("Moderating message from user %s in group %s", plan.user_id, plan.group_id)
+
+    if not plan.message_text.strip():
+        logger.debug("Empty message received; nothing to moderate.")
+        return ModerationReport(action=None, severity=0.0, notes="empty-message")
+
+    if not _detect_violation(plan.message_text, VIOLATION_KEYWORDS):
+        logger.debug("Message deemed safe; no action taken.")
+        return ModerationReport(action=None, severity=0.0)
+
+    warning_text = (
+        f"Moderation warning for {plan.user_id}: your recent message was flagged for review. "
+        "Please adhere to community guidelines."
+    )
+
+    logger.warning(
+        "Violation detected for user %s in group %s. Dispatching warning message.",
+        plan.user_id,
+        plan.group_id,
+    )
+
+    await groupme.messages.post_to_group(
+        group_id=plan.group_id,
+        source_guid=str(uuid4()),
+        text=warning_text,
+    )
+    return ModerationReport(action="warn", severity=0.8, notes="keyword-violation")


### PR DESCRIPTION
## Summary
- implement moderation workflow with severity reporting and warning dispatch
- add custom command, commerce, and intent detection workers with supporting tests
- wire up a message dispatcher stub in the CLI entry point and expose workers via the package init

## Testing
- pytest tests/test_workers_moderation.py tests/test_workers_commands.py tests/test_workers_commerce.py tests/test_workers_intent_detector.py

------
https://chatgpt.com/codex/tasks/task_e_68e1826383b48329b9e2f2f4fbd2a3a0