### PR TITLE
Ensure workflow suite honors checklist integrations

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,6 +1,6 @@
 from .client import GroupMeClient
 from .groups import GroupsAPI
-from .messages_api import MessagesAPI
+from .messages import MessagesAPI
 from .bots_api import BotsAPI
 from .users import UsersAPI
 from .blocks import BlocksAPI

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,33 @@
-"""Pytest configuration for path setup."""
+"""Pytest configuration for path setup and third-party stubs."""
+from __future__ import annotations
+
 import sys
 from pathlib import Path
+
+module = sys.modules.get("httpx")
+if module is not None and not hasattr(module, "Response"):  # pragma: no cover - replace stub
+    sys.modules.pop("httpx", None)
+
+try:  # pragma: no cover - import guard for optional dependency
+    import httpx  # noqa: F401
+except ModuleNotFoundError:  # pragma: no cover - fallback stub
+    from typing import Any
+
+    class _HttpxStub:
+        class AsyncClient:  # type: ignore[too-few-public-methods]
+            def __init__(self, *args: Any, **kwargs: Any) -> None:
+                self._kwargs = kwargs
+
+            async def get(self, *args: Any, **kwargs: Any) -> None:
+                raise RuntimeError("httpx.AsyncClient.get not stubbed")
+
+            async def post(self, *args: Any, **kwargs: Any) -> None:
+                raise RuntimeError("httpx.AsyncClient.post not stubbed")
+
+            async def aclose(self) -> None:
+                return None
+
+    sys.modules.setdefault("httpx", _HttpxStub())
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:

--- a/tests/test_api_workflows_suite.py
+++ b/tests/test_api_workflows_suite.py
@@ -1,0 +1,156 @@
+"""Integration-style tests for bot-facing API clients and routers."""
+from __future__ import annotations
+
+import types
+from typing import Any, Dict
+
+import pytest
+
+pytest.importorskip("pydantic")
+
+fastapi_module = pytest.importorskip("fastapi")
+testclient_module = pytest.importorskip("fastapi.testclient")
+
+FastAPI = fastapi_module.FastAPI
+TestClient = testclient_module.TestClient
+
+from app import bots_api as bots_api_module
+from app import groups as groups_module
+from app import messages as messages_module
+from app import chats as chats_module
+from app.chats import router as chats_router
+from app.dependencies import get_groupme_client, get_tenant_from_api_key
+
+
+@pytest.mark.asyncio
+async def test_messages_api_list_for_group_applies_filters():
+    """Ensure the Messages API forwards pagination filters to the client."""
+    client = types.SimpleNamespace()
+    captured: Dict[str, Any] = {}
+
+    async def fake_get(path: str, params: Dict[str, Any] | None = None):
+        captured["path"] = path
+        captured["params"] = params or {}
+        payload = {
+            "count": 1,
+            "messages": [
+                {
+                    "id": "m1",
+                    "group_id": "g1",
+                    "user_id": "u1",
+                    "name": "Tester",
+                    "created_at": 1,
+                    "text": "hello",
+                    "favorited_by": [],
+                    "source_guid": "guid-1",
+                }
+            ],
+        }
+        return types.SimpleNamespace(response=payload)
+
+    client._get = fake_get  # type: ignore[attr-defined]
+    api = messages_module.MessagesAPI(client)  # type: ignore[arg-type]
+
+    response = await api.list_for_group(
+        "g1", before_id="b2", since_id="s3", after_id="a4", limit=42
+    )
+
+    assert response.count == 1
+    assert captured["path"] == "/groups/g1/messages"
+    assert captured["params"] == {
+        "before_id": "b2",
+        "since_id": "s3",
+        "after_id": "a4",
+        "limit": 42,
+    }
+
+
+@pytest.mark.asyncio
+async def test_bots_api_post_message_includes_optional_picture():
+    """The Bots API must forward optional picture URLs when present."""
+    client = types.SimpleNamespace()
+    recorded_body: Dict[str, Any] = {}
+
+    async def fake_post(
+        path: str,
+        json: Dict[str, Any] | None = None,
+        params: Dict[str, Any] | None = None,
+    ):
+        recorded_body["path"] = path
+        recorded_body["json"] = json or {}
+        return types.SimpleNamespace(response={"status": "ok"})
+
+    client._post = fake_post  # type: ignore[attr-defined]
+    api = bots_api_module.BotsAPI(client)  # type: ignore[arg-type]
+
+    payload = await api.post_message("bot-1", "Hi there", picture_url="https://img")
+
+    assert payload == {"status": "ok"}
+    assert recorded_body["path"] == "/bots/post"
+    assert recorded_body["json"] == {
+        "bot_id": "bot-1",
+        "text": "Hi there",
+        "picture_url": "https://img",
+    }
+
+
+def _build_test_app(mock_client) -> FastAPI:
+    app = FastAPI()
+    app.include_router(chats_router)
+
+    async def fake_client(_: Any) -> Any:
+        return mock_client
+
+    async def fake_tenant(_: Any, x_api_key: str | None = None) -> Any:
+        return types.SimpleNamespace(id="tenant-1")
+
+    app.dependency_overrides[get_groupme_client] = fake_client
+    app.dependency_overrides[get_tenant_from_api_key] = fake_tenant
+    return app
+
+
+def test_chats_router_like_and_error_flow(monkeypatch):
+    """Verify chats router returns success and surfaces failures."""
+    mock_client = types.SimpleNamespace()
+
+    async def fake_like(conversation_id: str, message_id: str, tenant_id: str) -> None:
+        if message_id == "fail":
+            raise RuntimeError("boom")
+
+    async def fake_unlike(conversation_id: str, message_id: str, tenant_id: str) -> None:
+        return None
+
+    monkeypatch.setattr(chats_module, "_mock_like_message", fake_like)
+    monkeypatch.setattr(chats_module, "_mock_unlike_message", fake_unlike)
+
+    app = _build_test_app(mock_client)
+    client = TestClient(app)
+
+    ok_response = client.post("/api/v1/messages/conv-1/msg-1/like")
+    assert ok_response.status_code == 200
+    assert ok_response.json()["status"] == "success"
+
+    error_response = client.post("/api/v1/messages/conv-1/fail/like")
+    assert error_response.status_code == 500
+    assert error_response.json()["detail"] == "Failed to like message"
+
+
+@pytest.mark.asyncio
+async def test_groups_api_share_link_supports_invitation_hacks():
+    """Groups API should expose share URLs for ghost invitation workflows."""
+    mock_client = types.SimpleNamespace()
+    payload = [
+        {"id": "g1", "name": "Alpha", "share_url": "https://group/alpha"},
+        {"id": "g2", "name": "Beta", "share_url": None},
+    ]
+
+    async def fake_get(path: str, params: Dict[str, Any] | None = None):
+        return types.SimpleNamespace(response=payload)
+
+    mock_client._get = fake_get  # type: ignore[attr-defined]
+
+    api = groups_module.GroupsAPI(mock_client)  # type: ignore[arg-type]
+    groups = await api.list()
+
+    share_urls = [group.share_url for group in groups if group.share_url]
+    assert share_urls == ["https://group/alpha"]

--- a/tests/test_worker_growth_suite.py
+++ b/tests/test_worker_growth_suite.py
@@ -1,0 +1,98 @@
+"""Focused unit tests for worker utilities powering engagement workflows."""
+from __future__ import annotations
+
+import types
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+pytest.importorskip("pydantic")
+
+from workers.content_echo_worker import ContentEchoWorker, EchoRule
+from workers.engagement_worker import EngagementWorker
+from workers.tracking_worker import TrackingWorker
+from workers.intent_detector import IntentPlan, run_intent_detection_workflow
+from _schema.tracking import BrowserAction
+
+
+@pytest.mark.asyncio
+async def test_content_echo_worker_process_message_creates_echo_history():
+    """Messages matching rules should be echoed across groups."""
+    groupme_stub = types.SimpleNamespace(
+        messages=types.SimpleNamespace(
+            post_to_group=AsyncMock(return_value={"message": {"id": "echo-1"}})
+        )
+    )
+    worker = ContentEchoWorker(groupme_stub, MagicMock())
+    worker.echo_rules["g1"] = EchoRule(
+        source_group_id="g1",
+        target_group_ids=["g2"],
+        engagement_threshold=1,
+        echo_probability=1.0,
+    )
+    worker._get_message_engagement = AsyncMock(return_value=5)
+    worker._should_echo_content = AsyncMock(return_value=True)
+
+    message_data = {
+        "id": "m1",
+        "group_id": "g1",
+        "text": "Limited deal available now!",
+        "user_id": "u1",
+        "name": "Alice",
+    }
+
+    await worker.process_message_for_echo(message_data)
+
+    assert len(worker.echo_history) == 1
+    event = worker.echo_history[0]
+    assert event.target_group_id == "g2"
+    assert event.original_message_id == "m1"
+
+
+@pytest.mark.asyncio
+async def test_engagement_worker_tracks_user_activity_and_soft_opt_in():
+    """Engagement worker should create profiles while monitoring soft opt-ins."""
+    groupme_stub = types.SimpleNamespace(messages=types.SimpleNamespace(post_to_group=AsyncMock()))
+    worker = EngagementWorker(groupme_stub, MagicMock())
+    worker._check_soft_opt_in_signals = AsyncMock()
+    worker._update_group_engagement_metrics = AsyncMock()
+
+    await worker.track_user_engagement(
+        {
+            "user_id": "user-1",
+            "group_id": "group-1",
+            "tenant_id": "tenant-1",
+            "text": "I want to buy now",
+        }
+    )
+
+    profile_key = "tenant-1:group-1:user-1"
+    assert profile_key in worker.engagement_profiles
+    assert worker.engagement_profiles[profile_key].message_count == 1
+    worker._check_soft_opt_in_signals.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_tracking_worker_browser_interaction_records_metrics():
+    """Tracking worker should store browser interactions for analytics."""
+    worker = TrackingWorker(types.SimpleNamespace(tenant_id="tenant-1"), MagicMock())
+    worker.browser_config = types.SimpleNamespace(browser_type="chromium")
+
+    interaction_id = await worker.track_browser_interaction(
+        url="https://example.com",
+        action=BrowserAction.NAVIGATE,
+        parameters={"latency_budget_ms": 200},
+        result={"status": "ok"},
+    )
+
+    assert any(interaction.id == interaction_id for interaction in worker.browser_interactions)
+
+
+@pytest.mark.asyncio
+async def test_intent_detector_reports_commerce_intent():
+    """Intent detector should flag commerce-focused phrases with high confidence."""
+    plan = IntentPlan(message_text="Can I buy this product today?")
+    report = await run_intent_detection_workflow(plan)
+    assert report.intent == "commerce"
+    assert report.confidence >= 0.8

--- a/tests/test_workflow_end_to_end_engagement.py
+++ b/tests/test_workflow_end_to_end_engagement.py
@@ -1,0 +1,153 @@
+"""End-to-end style tests for engagement and commerce workflows."""
+from __future__ import annotations
+
+import asyncio
+import types
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from workflows.base import WorkflowContext
+from workflows.commerce_workflows import CommerceIntentWorkflow
+from workflows.engagement_workflows import (
+    AdaptiveFrequencyWorkflow,
+    OnboardingFunnelWorkflow,
+    ProgressivePermissionWorkflow,
+    SoftOptInWorkflow,
+)
+
+
+def test_adaptive_frequency_workflow_uses_engagement_worker():
+    """Adaptive frequency workflow should leverage engagement worker calculations."""
+    engagement_worker = types.SimpleNamespace(
+        get_adaptive_frequency=MagicMock(return_value=3.5),
+        burst_mode_active={"group-1": True},
+    )
+    chats_api = types.SimpleNamespace(
+        list_chats=AsyncMock(
+            return_value=[types.SimpleNamespace(messages_count=90)]
+        )
+    )
+    context = WorkflowContext(engagement_worker=engagement_worker, chats_api=chats_api)
+    workflow = AdaptiveFrequencyWorkflow()
+
+    result = asyncio.run(
+        workflow.execute(
+            context,
+            group_id="group-1",
+            content_type="promo",
+            target_frequency=2.0,
+        )
+    )
+
+    assert result.achieved_goal is True
+    assert result.metrics["calculated_frequency"] == 3.5
+    engagement_worker.get_adaptive_frequency.assert_called_once_with("group-1", "promo")
+    chats_api.list_chats.assert_awaited()
+
+
+def test_soft_opt_in_workflow_updates_profile_counts():
+    """Soft opt-in workflow should tally users flagged for opt-ins."""
+    profile = types.SimpleNamespace(soft_opted_in=True)
+    engagement_worker = types.SimpleNamespace(
+        engagement_profiles={"tenant:group:user": profile},
+        track_user_engagement=AsyncMock(),
+    )
+    bots_api = types.SimpleNamespace(post_message=AsyncMock())
+    context = WorkflowContext(engagement_worker=engagement_worker, bots_api=bots_api)
+    workflow = SoftOptInWorkflow()
+
+    result = asyncio.run(
+        workflow.execute(
+            context,
+            message={
+                "tenant_id": "tenant",
+                "group_id": "group",
+                "user_id": "user",
+                "text": "buy now",
+            },
+            acceptance_target=1,
+            bot_id="bot-1",
+        )
+    )
+
+    assert result.achieved_goal is True
+    assert result.metrics["soft_opt_in_users"] == 1
+    engagement_worker.track_user_engagement.assert_awaited()
+    bots_api.post_message.assert_awaited_once()
+
+
+def test_commerce_intent_workflow_scores_messages():
+    """Intent workflow should compute precision-like metrics for commerce intents."""
+    messages_api = types.SimpleNamespace(
+        list_for_group=AsyncMock(
+            return_value=types.SimpleNamespace(
+                messages=[types.SimpleNamespace(text="Fetched commerce offer")]
+            )
+        )
+    )
+    context = WorkflowContext(messages_api=messages_api)
+    workflow = CommerceIntentWorkflow()
+
+    result = asyncio.run(
+        workflow.execute(
+            context,
+                messages=["Can I buy this?", "Ready to purchase now"],
+                group_id="group-7",
+                precision_target=0.3,
+        )
+    )
+
+    assert result.metrics["commerce_intents"] >= 1
+    assert result.achieved_goal is True
+    messages_api.list_for_group.assert_awaited_once()
+
+
+def test_onboarding_funnel_workflow_triggers_outreach():
+    """Onboarding workflow should trigger direct messages for new users."""
+    engagement_worker = types.SimpleNamespace(
+        trigger_onboarding_dm=AsyncMock(),
+    )
+    bots_api = types.SimpleNamespace(post_message=AsyncMock())
+    context = WorkflowContext(engagement_worker=engagement_worker, bots_api=bots_api)
+    workflow = OnboardingFunnelWorkflow()
+
+    result = asyncio.run(
+        workflow.execute(
+            context,
+            group_id="group-x",
+            user_ids=["u1", "u2"],
+            bot_id="bot-42",
+        )
+    )
+
+    assert engagement_worker.trigger_onboarding_dm.await_count == 2
+    assert result.metrics["onboarded_users"] == 2
+    assert result.achieved_goal is True
+    assert bots_api.post_message.await_count == 2
+
+
+def test_progressive_permission_workflow_checks_gamification():
+    """Progressive permission workflow should request gamification updates."""
+    engagement_worker = types.SimpleNamespace(
+        check_gamification_progression=AsyncMock(),
+    )
+    groups_api = types.SimpleNamespace(
+        list=AsyncMock(return_value=[types.SimpleNamespace(id="group-x")])
+    )
+    context = WorkflowContext(engagement_worker=engagement_worker, groups_api=groups_api)
+    workflow = ProgressivePermissionWorkflow()
+
+    result = asyncio.run(
+        workflow.execute(
+            context,
+            group_id="group-x",
+            user_ids=["user-1"],
+            minimum_users=1,
+        )
+    )
+
+    engagement_worker.check_gamification_progression.assert_awaited_once()
+    groups_api.list.assert_awaited_once()
+    assert result.metrics["progressions_requested"] == 1
+    assert result.achieved_goal is True

--- a/tests/test_workflow_end_to_end_messaging.py
+++ b/tests/test_workflow_end_to_end_messaging.py
@@ -1,0 +1,168 @@
+"""End-to-end style tests for messaging and tracking workflows."""
+from __future__ import annotations
+
+import asyncio
+import types
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from workflows.base import WorkflowContext
+from workflows.growth_workflows import GhostInvitationWorkflow
+from workflows.message_workflows import AutoLikeFeedbackWorkflow, MessageStitchingWorkflow
+from workflows.tracking_workflows import ContentMiningWorkflow, RealTimeSubscriptionWorkflow
+
+
+def test_message_stitching_workflow_executes_cross_group_echoes():
+    """Workflow should stitch qualifying messages through the echo worker."""
+    messages_api = types.SimpleNamespace(
+        list_for_group=AsyncMock(
+            return_value=types.SimpleNamespace(
+                count=2,
+                messages=[
+                    types.SimpleNamespace(
+                        id="m1",
+                        source_guid="g1-1",
+                        created_at=1,
+                        user_id="u1",
+                        group_id="g1",
+                        name="User 1",
+                        text="Flash sale today",
+                    ),
+                    types.SimpleNamespace(
+                        id="m2",
+                        source_guid="g1-2",
+                        created_at=2,
+                        user_id="u2",
+                        group_id="g1",
+                        name="User 2",
+                        text="Limited offer",
+                    ),
+                ],
+            )
+        )
+    )
+    content_worker = types.SimpleNamespace(
+        process_message_for_echo=AsyncMock(),
+        echo_history=[],
+    )
+
+    async def _side_effect(message_data: dict[str, Any]) -> None:
+        content_worker.echo_history.append({"id": message_data["id"]})
+
+    content_worker.process_message_for_echo.side_effect = _side_effect
+
+    context = WorkflowContext(messages_api=messages_api, content_echo_worker=content_worker)
+    workflow = MessageStitchingWorkflow()
+    result = asyncio.run(
+        workflow.execute(
+            context,
+            group_id="g1",
+            limit=10,
+            target_echoes=2,
+        )
+    )
+
+    assert result.achieved_goal is True
+    assert result.metrics["processed_messages"] == 2
+    assert result.metrics["echoed_messages"] == 2
+
+
+def test_auto_like_feedback_workflow_posts_reactions():
+    """Auto-like workflow should forward reactions to the messages API."""
+    messages_api = types.SimpleNamespace(post_to_group=AsyncMock())
+    context = WorkflowContext(messages_api=messages_api)
+    workflow = AutoLikeFeedbackWorkflow()
+
+    result = asyncio.run(
+        workflow.execute(
+            context,
+            group_id="g42",
+            message_ids=["m1", "m2"],
+            reaction_text="👍",
+        )
+    )
+
+    assert result.metrics["processed_messages"] == 2
+    assert messages_api.post_to_group.await_count == 2
+    assert result.achieved_goal is True
+
+
+def test_real_time_subscription_workflow_tracks_events():
+    """Real-time workflow should send captured events to tracking worker."""
+    messages_api = types.SimpleNamespace(
+        list_for_group=AsyncMock(
+            return_value=types.SimpleNamespace(
+                count=1,
+                messages=[
+                    types.SimpleNamespace(
+                        id="m3",
+                        source_guid="g1-3",
+                        created_at=3,
+                        user_id="u3",
+                        group_id="g9",
+                        name="User 3",
+                        text="Engagement spike",
+                    )
+                ],
+            )
+        )
+    )
+    tracking_worker = types.SimpleNamespace(
+        track_browser_interaction=AsyncMock(return_value="event-1"),
+        browser_interactions=[],
+    )
+
+    async def _track(url: str, action: Any, parameters: dict[str, Any], result: dict[str, Any] | None = None):
+        tracking_worker.browser_interactions.append({"url": url, "parameters": parameters})
+        return "event-1"
+
+    tracking_worker.track_browser_interaction.side_effect = _track
+
+    context = WorkflowContext(messages_api=messages_api, tracking_worker=tracking_worker)
+    workflow = RealTimeSubscriptionWorkflow()
+    result = asyncio.run(workflow.execute(context, group_id="g9", limit=5))
+
+    assert result.metrics["captured_events"] == 1
+    assert tracking_worker.browser_interactions
+
+
+def test_ghost_invitation_workflow_generates_links():
+    """Ghost invitation workflow should return shareable invite links."""
+    groups_api = types.SimpleNamespace(
+        list=AsyncMock(
+            return_value=[
+                types.SimpleNamespace(id="g1", name="Alpha", share_url="https://group/alpha"),
+                types.SimpleNamespace(id="g2", name="Beta", share_url=None),
+            ]
+        )
+    )
+    context = WorkflowContext(groups_api=groups_api)
+    workflow = GhostInvitationWorkflow()
+    result = asyncio.run(
+        workflow.execute(context, target_groups=["g1", "g2"], minimum_links=1)
+    )
+
+    assert result.achieved_goal is True
+    assert result.metrics["generated_links"] == ["https://group/alpha"]
+
+
+def test_content_mining_workflow_combines_sources():
+    """Content mining workflow should merge echo and tracking analytics."""
+    content_worker = types.SimpleNamespace(
+        run_content_mining=AsyncMock(return_value={"trending_topics": ["deal"]})
+    )
+    tracking_worker = types.SimpleNamespace(
+        get_comprehensive_analytics=AsyncMock(return_value={"knowledge_base": []})
+    )
+    context = WorkflowContext(
+        content_echo_worker=content_worker,
+        tracking_worker=tracking_worker,
+    )
+    workflow = ContentMiningWorkflow()
+    result = asyncio.run(workflow.execute(context, minimum_topics=1))
+
+    assert result.metrics["trending_topics"] == ["deal"]
+    assert result.metrics["analytics_snapshot"] == {"knowledge_base": []}
+    assert result.achieved_goal is True

--- a/workers/base_worker.py
+++ b/workers/base_worker.py
@@ -1,0 +1,27 @@
+"""Minimal base worker to provide shared utilities for worker classes."""
+from __future__ import annotations
+
+from typing import Any, Iterable, List
+
+from app.models import Group
+
+
+class BaseWorker:
+    """Simple base class exposing common attributes for workers."""
+
+    def __init__(self, groupme_client: Any, db_session: Any) -> None:
+        self.groupme = groupme_client
+        self.db_session = db_session
+        self.is_running: bool = False
+        self.tenant_id: str | None = getattr(groupme_client, "tenant_id", None)
+
+    async def initialize(self) -> None:  # pragma: no cover - default no-op
+        """Hook for worker initialization."""
+
+    async def get_active_groups(self) -> Iterable[Group]:  # pragma: no cover - default no-op
+        """Return active groups for the tenant."""
+        return []
+
+    async def get_recent_group_activity(self, group_id: str, hours: int = 24) -> List[dict[str, Any]]:  # type: ignore[name-defined]
+        """Return mock recent activity for a group."""
+        return []

--- a/workflows/__init__.py
+++ b/workflows/__init__.py
@@ -1,0 +1,30 @@
+"""Workflow package aggregating orchestrated engagement strategies."""
+from .base import WorkflowContext, WorkflowKPI, WorkflowResult
+from .commerce_workflows import CommerceIntentWorkflow
+from .engagement_workflows import (
+    AdaptiveFrequencyWorkflow,
+    OnboardingFunnelWorkflow,
+    ProgressivePermissionWorkflow,
+    SoftOptInWorkflow,
+)
+from .growth_workflows import GhostInvitationWorkflow
+from .message_workflows import AutoLikeFeedbackWorkflow, MessageStitchingWorkflow
+from .tracking_workflows import ContentMiningWorkflow, RealTimeSubscriptionWorkflow
+from .workflow_suite import WORKFLOW_REGISTRY
+
+__all__ = [
+    "AdaptiveFrequencyWorkflow",
+    "AutoLikeFeedbackWorkflow",
+    "CommerceIntentWorkflow",
+    "ContentMiningWorkflow",
+    "GhostInvitationWorkflow",
+    "MessageStitchingWorkflow",
+    "OnboardingFunnelWorkflow",
+    "ProgressivePermissionWorkflow",
+    "RealTimeSubscriptionWorkflow",
+    "SoftOptInWorkflow",
+    "WorkflowContext",
+    "WorkflowKPI",
+    "WorkflowResult",
+    "WORKFLOW_REGISTRY",
+]

--- a/workflows/base.py
+++ b/workflows/base.py
@@ -1,0 +1,61 @@
+"""Shared workflow definitions and context helpers."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional, Sequence
+
+
+@dataclass(slots=True)
+class WorkflowKPI:
+    """Represents an individual KPI for a workflow."""
+
+    name: str
+    target: str
+    description: str
+
+
+@dataclass(slots=True)
+class WorkflowResult:
+    """Aggregate result returned by workflow execution."""
+
+    achieved_goal: bool
+    metrics: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class WorkflowContext:
+    """Holds worker and API dependencies shared across workflows."""
+
+    messages_api: Optional["MessagesAPI"] = None
+    bots_api: Optional["BotsAPI"] = None
+    chats_api: Optional["ChatsAPI"] = None
+    groups_api: Optional["GroupsAPI"] = None
+    engagement_worker: Optional["EngagementWorker"] = None
+    content_echo_worker: Optional["ContentEchoWorker"] = None
+    tracking_worker: Optional["TrackingWorker"] = None
+
+
+class WorkflowDefinition:
+    """Base class for all orchestrated workflows."""
+
+    name: str
+    goal: str
+    kpis: Sequence[WorkflowKPI]
+
+    async def execute(self, context: WorkflowContext, **kwargs: Any) -> WorkflowResult:  # pragma: no cover - interface
+        raise NotImplementedError
+
+    @staticmethod
+    def _require(context: WorkflowContext, attribute: str) -> Any:
+        value = getattr(context, attribute)
+        if value is None:
+            raise ValueError(f"Workflow requires '{attribute}' in context")
+        return value
+
+
+__all__ = [
+    "WorkflowKPI",
+    "WorkflowResult",
+    "WorkflowContext",
+    "WorkflowDefinition",
+]

--- a/workflows/commerce_workflows.py
+++ b/workflows/commerce_workflows.py
@@ -1,0 +1,58 @@
+"""Workflow focused on commerce intent detection."""
+from __future__ import annotations
+
+from typing import Any, Sequence
+
+from workers.intent_detector import IntentPlan, run_intent_detection_workflow
+
+from .base import WorkflowContext, WorkflowDefinition, WorkflowKPI, WorkflowResult
+
+
+class CommerceIntentWorkflow(WorkflowDefinition):
+    """Detect commerce intents for downstream monetisation workflows."""
+
+    name = "commerce_intent_detection"
+    goal = "Maintain commerce intent precision above 0.8 with <50 LLM calls per group."
+    kpis = (
+        WorkflowKPI("precision", ">=0.8", "Commerce intent precision"),
+        WorkflowKPI("llm_call_volume", "<50", "Model invocations per group"),
+    )
+
+    async def execute(self, context: WorkflowContext, **kwargs: Any) -> WorkflowResult:
+        messages_api = self._require(context, "messages_api")
+
+        messages: Sequence[str] = kwargs.get("messages", [])
+        precision_target: float = kwargs.get("precision_target", 0.8)
+        minimum_commerce: int = kwargs.get("minimum_commerce", 1)
+        group_id: str | None = kwargs.get("group_id")
+        fetch_limit: int = kwargs.get("limit", 20)
+
+        fetched_messages = []
+        if group_id:
+            response = await messages_api.list_for_group(group_id, limit=fetch_limit)
+            fetched_messages = [message.text or "" for message in response.messages]
+            if not messages:
+                messages = fetched_messages
+            else:
+                messages = list(messages) + fetched_messages
+
+        intents = []
+        for message in messages:
+            report = await run_intent_detection_workflow(IntentPlan(message_text=message))
+            intents.append(report)
+
+        commerce_intents = sum(1 for report in intents if report.intent == "commerce")
+        precision = commerce_intents / len(messages) if messages else 0.0
+
+        metrics = {
+            "total_messages": len(messages),
+            "commerce_intents": commerce_intents,
+            "precision": precision,
+            "group_id": group_id,
+            "messages_sourced": len(fetched_messages),
+        }
+        achieved = precision >= precision_target and commerce_intents >= minimum_commerce
+        return WorkflowResult(achieved_goal=achieved, metrics=metrics)
+
+
+__all__ = ["CommerceIntentWorkflow"]

--- a/workflows/engagement_workflows.py
+++ b/workflows/engagement_workflows.py
@@ -1,0 +1,189 @@
+"""Workflows managing engagement cadence and user onboarding."""
+from __future__ import annotations
+
+from typing import Any, Sequence
+
+from .base import WorkflowContext, WorkflowDefinition, WorkflowKPI, WorkflowResult
+
+
+class AdaptiveFrequencyWorkflow(WorkflowDefinition):
+    """Control outbound cadence based on engagement heuristics."""
+
+    name = "adaptive_frequency_control"
+    goal = "Maintain adaptive send frequency to improve engagement by 20%."
+    kpis = (
+        WorkflowKPI("frequency_alignment", ">=90%", "Messages within adaptive band"),
+        WorkflowKPI("burst_mode_latency", "<5m", "Reaction time to burst activations"),
+    )
+
+    async def execute(self, context: WorkflowContext, **kwargs: Any) -> WorkflowResult:
+        engagement_worker = self._require(context, "engagement_worker")
+        chats_api = self._require(context, "chats_api")
+
+        group_id: str = kwargs["group_id"]
+        content_type: str = kwargs.get("content_type", "general")
+        target_frequency: float = kwargs.get("target_frequency", 1.0)
+        chat_window_hours: int = kwargs.get("chat_window_hours", 24)
+        conversation_limit: int = kwargs.get("conversation_limit", 10)
+
+        frequency = engagement_worker.get_adaptive_frequency(group_id, content_type)
+        burst_mode = bool(getattr(engagement_worker, "burst_mode_active", {}).get(group_id))
+
+        chats_snapshot = await chats_api.list_chats(
+            group_id=group_id,
+            window_hours=chat_window_hours,
+            limit=conversation_limit,
+        )
+
+        def _count_messages(chat: Any) -> int:
+            if hasattr(chat, "messages_count"):
+                return int(getattr(chat, "messages_count"))
+            if isinstance(chat, dict):
+                return int(chat.get("messages_count", 0))
+            return 0
+
+        observed_messages = sum(_count_messages(chat) for chat in chats_snapshot)
+        window = max(chat_window_hours, 1)
+        observed_frequency = observed_messages / window
+        if target_frequency <= 0:
+            alignment_ratio = 1.0
+        else:
+            alignment_ratio = min(observed_frequency / target_frequency, 1.0)
+
+        metrics = {
+            "calculated_frequency": frequency,
+            "target_frequency": target_frequency,
+            "burst_mode": burst_mode,
+            "observed_frequency": observed_frequency,
+            "alignment_ratio": alignment_ratio,
+            "chats_sampled": len(chats_snapshot),
+        }
+        achieved = frequency >= target_frequency and alignment_ratio >= 0.9
+        return WorkflowResult(achieved_goal=achieved, metrics=metrics)
+
+
+class SoftOptInWorkflow(WorkflowDefinition):
+    """Identify and enroll users showing commercial interest."""
+
+    name = "soft_opt_in_capture"
+    goal = "Capture soft opt-in interest from at least 70% of engaged members."
+    kpis = (
+        WorkflowKPI("soft_opt_in_rate", ">=0.7", "Users with soft opt-in state"),
+        WorkflowKPI("follow_up_latency", "<10m", "Time to react to opt-in signal"),
+    )
+
+    async def execute(self, context: WorkflowContext, **kwargs: Any) -> WorkflowResult:
+        engagement_worker = self._require(context, "engagement_worker")
+        bots_api = self._require(context, "bots_api")
+
+        message_payload: dict[str, Any] = kwargs["message"]
+        acceptance_target: int = kwargs.get("acceptance_target", 5)
+        bot_id = kwargs.get("bot_id")
+        if not bot_id:
+            raise ValueError("SoftOptInWorkflow requires 'bot_id' to message users")
+        follow_up_text: str = kwargs.get(
+            "follow_up_text",
+            "Thanks for the interest! Reply YES to confirm deals.",
+        )
+
+        await engagement_worker.track_user_engagement(message_payload)
+        profiles = getattr(engagement_worker, "engagement_profiles", {})
+        soft_opt_count = sum(
+            1 for profile in profiles.values() if getattr(profile, "soft_opted_in", False)
+        )
+
+        await bots_api.post_message(
+            bot_id=bot_id,
+            text=f"{follow_up_text}"
+            f" (user={message_payload.get('user_id', 'unknown')})",
+        )
+
+        metrics = {
+            "soft_opt_in_users": soft_opt_count,
+            "acceptance_target": acceptance_target,
+            "bot_id": bot_id,
+        }
+        achieved = soft_opt_count >= acceptance_target
+        return WorkflowResult(achieved_goal=achieved, metrics=metrics)
+
+
+class OnboardingFunnelWorkflow(WorkflowDefinition):
+    """Guide new members through onboarding touch-points."""
+
+    name = "onboarding_funnel_automation"
+    goal = "Deliver onboarding nudges to 90% of new members within 24 hours."
+    kpis = (
+        WorkflowKPI("nudge_coverage", ">=0.9", "Fraction of new users nudged"),
+        WorkflowKPI("follow_up_completion", ">=0.7", "Users completing onboarding"),
+    )
+
+    async def execute(self, context: WorkflowContext, **kwargs: Any) -> WorkflowResult:
+        engagement_worker = self._require(context, "engagement_worker")
+        bots_api = self._require(context, "bots_api")
+
+        group_id: str = kwargs["group_id"]
+        user_ids: Sequence[str] = kwargs.get("user_ids", [])
+        minimum_users: int = kwargs.get("minimum_users", 1)
+        bot_id = kwargs.get("bot_id")
+        if not bot_id:
+            raise ValueError("OnboardingFunnelWorkflow requires 'bot_id' to welcome members")
+        welcome_message: str = kwargs.get(
+            "welcome_message",
+            "Welcome aboard! Check pinned posts for starter kits.",
+        )
+
+        for user_id in user_ids:
+            await engagement_worker.trigger_onboarding_dm(user_id, group_id)
+            await bots_api.post_message(
+                bot_id=bot_id,
+                text=f"{welcome_message} @user:{user_id}",
+            )
+
+        metrics = {
+            "onboarded_users": len(user_ids),
+            "minimum_users": minimum_users,
+            "bot_id": bot_id,
+        }
+        achieved = len(user_ids) >= minimum_users
+        return WorkflowResult(achieved_goal=achieved, metrics=metrics)
+
+
+class ProgressivePermissionWorkflow(WorkflowDefinition):
+    """Unlock gamification levels as engagement improves."""
+
+    name = "progressive_permission_gamification"
+    goal = "Advance engaged members to higher gamification tiers weekly."
+    kpis = (
+        WorkflowKPI("progressions_processed", ">=10", "Users evaluated for progression"),
+        WorkflowKPI("upgrade_rate", ">=0.4", "Share of users upgraded"),
+    )
+
+    async def execute(self, context: WorkflowContext, **kwargs: Any) -> WorkflowResult:
+        engagement_worker = self._require(context, "engagement_worker")
+        groups_api = self._require(context, "groups_api")
+
+        group_id: str = kwargs["group_id"]
+        user_ids: Sequence[str] = kwargs.get("user_ids", [])
+        minimum_users: int = kwargs.get("minimum_users", 1)
+
+        for user_id in user_ids:
+            await engagement_worker.check_gamification_progression(user_id, group_id)
+
+        groups = await groups_api.list()
+        target_group = next((group for group in groups if getattr(group, "id", None) == group_id), None)
+
+        metrics = {
+            "progressions_requested": len(user_ids),
+            "minimum_users": minimum_users,
+            "group_found": bool(target_group),
+        }
+        achieved = len(user_ids) >= minimum_users and target_group is not None
+        return WorkflowResult(achieved_goal=achieved, metrics=metrics)
+
+
+__all__ = [
+    "AdaptiveFrequencyWorkflow",
+    "SoftOptInWorkflow",
+    "OnboardingFunnelWorkflow",
+    "ProgressivePermissionWorkflow",
+]

--- a/workflows/growth_workflows.py
+++ b/workflows/growth_workflows.py
@@ -1,0 +1,42 @@
+"""Workflows that emphasise group growth and share link distribution."""
+from __future__ import annotations
+
+from typing import Any, Iterable, List, Optional
+
+from .base import WorkflowContext, WorkflowDefinition, WorkflowKPI, WorkflowResult
+
+
+class GhostInvitationWorkflow(WorkflowDefinition):
+    """Generate dynamic share links for stealth invitations."""
+
+    name = "ghost_invitation_share_links"
+    goal = "Produce at least 3 valid share links for invite campaigns."
+    kpis = (
+        WorkflowKPI("valid_share_links", ">=3", "Active share URLs harvested"),
+        WorkflowKPI("invitation_conversion", ">=20%", "Ghost invite acceptance"),
+    )
+
+    async def execute(self, context: WorkflowContext, **kwargs: Any) -> WorkflowResult:
+        groups_api = self._require(context, "groups_api")
+
+        target_groups: Optional[Iterable[str]] = kwargs.get("target_groups")
+        minimum_links: int = kwargs.get("minimum_links", 3)
+
+        groups = await groups_api.list()
+        links: List[str] = []
+
+        for group in groups:
+            if target_groups and group.id not in set(target_groups):
+                continue
+            if group.share_url:
+                links.append(group.share_url)
+
+        metrics = {
+            "generated_links": links,
+            "minimum_links": minimum_links,
+        }
+        achieved = len(links) >= minimum_links
+        return WorkflowResult(achieved_goal=achieved, metrics=metrics)
+
+
+__all__ = ["GhostInvitationWorkflow"]

--- a/workflows/message_workflows.py
+++ b/workflows/message_workflows.py
@@ -1,0 +1,89 @@
+"""Workflows focused on message distribution and reactions."""
+from __future__ import annotations
+
+from typing import Any, Sequence
+from uuid import uuid4
+
+from .base import WorkflowContext, WorkflowDefinition, WorkflowKPI, WorkflowResult
+
+
+class MessageStitchingWorkflow(WorkflowDefinition):
+    """Stitch and echo high-engagement content across groups."""
+
+    name = "message_stitching_content_echo"
+    goal = "Amplify cross-group engagement by echoing at least 5 high-signal messages per run."
+    kpis = (
+        WorkflowKPI("qualified_messages", ">=5", "Messages stitched across communities"),
+        WorkflowKPI("echo_success_rate", ">=0.8", "Share of qualifying messages echoed"),
+    )
+
+    async def execute(self, context: WorkflowContext, **kwargs: Any) -> WorkflowResult:
+        messages_api = self._require(context, "messages_api")
+        content_worker = self._require(context, "content_echo_worker")
+
+        group_id: str = kwargs["group_id"]
+        limit: int = kwargs.get("limit", 50)
+        target_echoes: int = kwargs.get("target_echoes", 5)
+
+        response = await messages_api.list_for_group(group_id, limit=limit)
+        baseline = len(getattr(content_worker, "echo_history", []))
+
+        for message in response.messages:
+            payload = {
+                "id": message.id,
+                "group_id": message.group_id or group_id,
+                "user_id": message.user_id,
+                "text": message.text or "",
+                "name": message.name or "Community Member",
+            }
+            await content_worker.process_message_for_echo(payload)
+
+        updated = len(getattr(content_worker, "echo_history", []))
+        echoed_messages = max(0, updated - baseline)
+
+        metrics = {
+            "processed_messages": response.count,
+            "echoed_messages": echoed_messages,
+            "target_echoes": target_echoes,
+        }
+        achieved = echoed_messages >= target_echoes
+        return WorkflowResult(achieved_goal=achieved, metrics=metrics)
+
+
+class AutoLikeFeedbackWorkflow(WorkflowDefinition):
+    """Close the feedback loop by reacting to high-value messages."""
+
+    name = "auto_like_feedback_loop"
+    goal = "Acknowledge 100% of priority messages with bot reactions."
+    kpis = (
+        WorkflowKPI("reaction_coverage", "100%", "Messages receiving auto-like"),
+        WorkflowKPI("feedback_latency", "<30s", "Time to react after detection"),
+    )
+
+    async def execute(self, context: WorkflowContext, **kwargs: Any) -> WorkflowResult:
+        messages_api = self._require(context, "messages_api")
+
+        group_id: str = kwargs["group_id"]
+        message_ids: Sequence[str] = kwargs.get("message_ids", [])
+        reaction_text: str = kwargs.get("reaction_text", "👍")
+        feedback_suffix: str = kwargs.get("feedback_suffix", "#CommunityBoost")
+
+        for message_id in message_ids:
+            await messages_api.post_to_group(
+                group_id=group_id,
+                source_guid=str(uuid4()),
+                text=f"{reaction_text} {feedback_suffix}",
+            )
+
+        metrics = {
+            "processed_messages": len(message_ids),
+            "reaction_text": reaction_text,
+        }
+        achieved = len(message_ids) > 0
+        return WorkflowResult(achieved_goal=achieved, metrics=metrics)
+
+
+__all__ = [
+    "MessageStitchingWorkflow",
+    "AutoLikeFeedbackWorkflow",
+]

--- a/workflows/tracking_workflows.py
+++ b/workflows/tracking_workflows.py
@@ -1,0 +1,100 @@
+"""Workflows leveraging tracking analytics and browser instrumentation."""
+from __future__ import annotations
+import importlib.util
+from enum import Enum
+from typing import Any
+
+_pydantic_spec = importlib.util.find_spec("pydantic")
+_tracking_spec = importlib.util.find_spec("_schema.tracking")
+if _tracking_spec is not None and _pydantic_spec is not None:
+    from _schema.tracking import BrowserAction
+else:
+    class BrowserAction(str, Enum):  # type: ignore[too-many-ancestors]
+        """Fallback browser actions when tracking schema is unavailable."""
+
+        NAVIGATE = "navigate"
+        CLICK = "click"
+        TYPE = "type"
+        SCROLL = "scroll"
+        WAIT = "wait"
+        SCREENSHOT = "screenshot"
+        EXTRACT = "extract"
+
+from .base import WorkflowContext, WorkflowDefinition, WorkflowKPI, WorkflowResult
+
+
+class RealTimeSubscriptionWorkflow(WorkflowDefinition):
+    """Capture near real-time engagement events via long polling."""
+
+    name = "real_time_event_capture"
+    goal = "Capture 95% of high-signal events within the last polling window."
+    kpis = (
+        WorkflowKPI("event_capture_rate", ">=0.95", "Share of events logged"),
+        WorkflowKPI("mean_latency", "<2s", "Average delay from detection to log"),
+    )
+
+    async def execute(self, context: WorkflowContext, **kwargs: Any) -> WorkflowResult:
+        messages_api = self._require(context, "messages_api")
+        tracking_worker = self._require(context, "tracking_worker")
+
+        group_id: str = kwargs["group_id"]
+        limit: int = kwargs.get("limit", 20)
+        minimum_events: int = kwargs.get("minimum_events", 1)
+
+        response = await messages_api.list_for_group(group_id, limit=limit)
+        captured = 0
+
+        for message in response.messages:
+            await tracking_worker.track_browser_interaction(
+                url=f"groupme://groups/{group_id}/messages/{message.id}",
+                action=BrowserAction.NAVIGATE,
+                parameters={
+                    "group_id": group_id,
+                    "message_id": message.id,
+                    "user_id": message.user_id,
+                },
+                result={"text": message.text or ""},
+            )
+            captured += 1
+
+        metrics = {
+            "captured_events": captured,
+            "minimum_events": minimum_events,
+        }
+        achieved = captured >= minimum_events
+        return WorkflowResult(achieved_goal=achieved, metrics=metrics)
+
+
+class ContentMiningWorkflow(WorkflowDefinition):
+    """Blend content mining insights with tracking analytics."""
+
+    name = "content_mining_micro_targeting"
+    goal = "Surface at least two trending topics for micro-targeting daily."
+    kpis = (
+        WorkflowKPI("trending_topics", ">=2", "Trending topics identified"),
+        WorkflowKPI("insight_latency", "<1h", "Time to refresh mining output"),
+    )
+
+    async def execute(self, context: WorkflowContext, **kwargs: Any) -> WorkflowResult:
+        content_worker = self._require(context, "content_echo_worker")
+        tracking_worker = self._require(context, "tracking_worker")
+
+        mining_snapshot = await content_worker.run_content_mining()
+        analytics_snapshot = await tracking_worker.get_comprehensive_analytics()
+
+        topics = mining_snapshot.get("trending_topics", [])
+        minimum_topics: int = kwargs.get("minimum_topics", 2)
+
+        metrics = {
+            "trending_topics": topics,
+            "analytics_snapshot": analytics_snapshot,
+            "minimum_topics": minimum_topics,
+        }
+        achieved = len(topics) >= minimum_topics
+        return WorkflowResult(achieved_goal=achieved, metrics=metrics)
+
+
+__all__ = [
+    "RealTimeSubscriptionWorkflow",
+    "ContentMiningWorkflow",
+]

--- a/workflows/workflow_suite.py
+++ b/workflows/workflow_suite.py
@@ -1,0 +1,47 @@
+"""Aggregate access to orchestrated workflows and registry helpers."""
+from __future__ import annotations
+
+from .base import WorkflowContext, WorkflowKPI, WorkflowResult
+from .commerce_workflows import CommerceIntentWorkflow
+from .engagement_workflows import (
+    AdaptiveFrequencyWorkflow,
+    OnboardingFunnelWorkflow,
+    ProgressivePermissionWorkflow,
+    SoftOptInWorkflow,
+)
+from .growth_workflows import GhostInvitationWorkflow
+from .message_workflows import AutoLikeFeedbackWorkflow, MessageStitchingWorkflow
+from .tracking_workflows import ContentMiningWorkflow, RealTimeSubscriptionWorkflow
+
+WORKFLOW_REGISTRY = {
+    workflow.name: workflow
+    for workflow in (
+        MessageStitchingWorkflow(),
+        AdaptiveFrequencyWorkflow(),
+        SoftOptInWorkflow(),
+        RealTimeSubscriptionWorkflow(),
+        GhostInvitationWorkflow(),
+        AutoLikeFeedbackWorkflow(),
+        ContentMiningWorkflow(),
+        CommerceIntentWorkflow(),
+        OnboardingFunnelWorkflow(),
+        ProgressivePermissionWorkflow(),
+    )
+}
+
+__all__ = [
+    "AdaptiveFrequencyWorkflow",
+    "AutoLikeFeedbackWorkflow",
+    "CommerceIntentWorkflow",
+    "ContentMiningWorkflow",
+    "GhostInvitationWorkflow",
+    "MessageStitchingWorkflow",
+    "OnboardingFunnelWorkflow",
+    "ProgressivePermissionWorkflow",
+    "RealTimeSubscriptionWorkflow",
+    "SoftOptInWorkflow",
+    "WorkflowContext",
+    "WorkflowKPI",
+    "WorkflowResult",
+    "WORKFLOW_REGISTRY",
+]


### PR DESCRIPTION
## Summary
- require workflow contexts to supply the chats, bots, groups, and messages APIs so each checklist workflow invokes the mandated integrations
- extend commerce and tracking workflows to fetch messages and fall back when optional schema dependencies are unavailable
- harden the workflow and API test suites to run without optional packages by stubbing data models, using asyncio.run, and skipping cases when dependencies are missing

## Testing
- `pytest tests/test_workflow_end_to_end_engagement.py tests/test_workflow_end_to_end_messaging.py tests/test_api_workflows_suite.py tests/test_worker_growth_suite.py`


------
https://chatgpt.com/codex/tasks/task_e_68e19591cd108329a16dfb091e045292