### PR TITLE
Improve NiceGUI stub output for local execution

### DIFF
--- a/_schema/bot_optimization.py
+++ b/_schema/bot_optimization.py
@@ -4,7 +4,7 @@ import uuid
 from datetime import datetime, timedelta
 from typing import Optional, Dict, Any, List, Tuple
 from collections import Counter, defaultdict
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 from dataclasses import dataclass
 
 # Import models from analytics module
@@ -37,8 +37,7 @@ class OptimizationRecommendation(BaseModel):
     created_at: datetime = Field(default_factory=datetime.utcnow)
     implemented_at: Optional[datetime] = None
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)
 
 class ABTestResult(BaseModel):
     """Stores results of A/B tests for monetization strategies."""
@@ -69,8 +68,7 @@ class ABTestResult(BaseModel):
     created_at: datetime = Field(default_factory=datetime.utcnow)
     completed_at: Optional[datetime] = None
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)
 
 @dataclass
 class MonetizationInsights:

--- a/_schema/platform/support.py
+++ b/_schema/platform/support.py
@@ -4,7 +4,7 @@ import uuid
 from datetime import datetime
 from typing import Optional, Dict, Any
 from enum import Enum
-from pydantic import BaseModel, Field, EmailStr
+from pydantic import BaseModel, ConfigDict, EmailStr, Field
 
 class ContactMethod(str, Enum):
     EMAIL = "email"
@@ -91,5 +91,4 @@ class GroupMember(BaseModel):
     created_at: datetime = Field(default_factory=datetime.utcnow)
     updated_at: datetime = Field(default_factory=datetime.utcnow)
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)

--- a/_schema/schemas/analytics.py
+++ b/_schema/schemas/analytics.py
@@ -4,7 +4,7 @@ import uuid
 from datetime import datetime
 from typing import Optional, Dict, Any, List
 from enum import Enum
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 class AIUsage(BaseModel):
     """Tracks individual AI usage events."""
@@ -24,8 +24,7 @@ class AIUsage(BaseModel):
 
     created_at: datetime = Field(default_factory=datetime.utcnow)
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)
 
 class CommandUsage(BaseModel):
     """Tracks executions of custom commands."""
@@ -45,8 +44,7 @@ class CommandUsage(BaseModel):
 
     created_at: datetime = Field(default_factory=datetime.utcnow)
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)
 
 class GroupDailyStats(BaseModel):
     """Daily aggregated statistics for a group."""
@@ -83,8 +81,7 @@ class GroupDailyStats(BaseModel):
     created_at: datetime = Field(default_factory=datetime.utcnow)
     updated_at: datetime = Field(default_factory=datetime.utcnow)
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)
 
 class TenantMonthlyStats(BaseModel):
     """Monthly aggregated statistics for a tenant."""
@@ -119,8 +116,7 @@ class TenantMonthlyStats(BaseModel):
     created_at: datetime = Field(default_factory=datetime.utcnow)
     updated_at: datetime = Field(default_factory=datetime.utcnow)
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)
 
 class SystemHealth(BaseModel):
     """Tracks overall system health and performance metrics."""
@@ -148,8 +144,7 @@ class SystemHealth(BaseModel):
     # Metadata
     metadata: Dict[str, Any] = Field(default_factory=dict, description="Additional system metadata")
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)
 
 class BotInteraction(BaseModel):
     """Logs every interaction between a user and a bot."""
@@ -175,8 +170,7 @@ class BotInteraction(BaseModel):
 
     created_at: datetime = Field(default_factory=datetime.utcnow)
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)
 
 class MonetizationEventLog(BaseModel):
     """Captures successful monetization events."""
@@ -196,8 +190,7 @@ class MonetizationEventLog(BaseModel):
 
     created_at: datetime = Field(default_factory=datetime.utcnow)
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)
 
 class MetricCategory(str, Enum):
     CUSTOMER_EXPERIENCE = "customer_experience"
@@ -285,8 +278,7 @@ class BotPerformanceMetrics(BaseModel):
     created_at: datetime = Field(default_factory=datetime.utcnow)
     updated_at: datetime = Field(default_factory=datetime.utcnow)
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)
 
 class CustomerFeedback(BaseModel):
     """Stores customer feedback and satisfaction ratings."""
@@ -309,8 +301,7 @@ class CustomerFeedback(BaseModel):
 
     created_at: datetime = Field(default_factory=datetime.utcnow)
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)
 
 class AggregatedKPIs(BaseModel):
     """Stores aggregated KPIs for reporting and analysis."""
@@ -354,8 +345,7 @@ class AggregatedKPIs(BaseModel):
 
     created_at: datetime = Field(default_factory=datetime.utcnow)
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)
 
 class ConversionTracking(BaseModel):
     """Tracks bot-initiated conversions, checkouts, and user outcomes."""
@@ -403,5 +393,4 @@ class ConversionTracking(BaseModel):
     created_at: datetime = Field(default_factory=datetime.utcnow)
     converted_at: Optional[datetime] = Field(None, description="When the conversion was completed")
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)

--- a/_schema/schemas/bots.py
+++ b/_schema/schemas/bots.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import uuid
 from datetime import datetime
 from typing import Dict, Any, List
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 class ChatBot(BaseModel):
     """Defines an AI bot and its capabilities."""
@@ -24,5 +24,4 @@ class ChatBot(BaseModel):
     created_at: datetime = Field(default_factory=datetime.utcnow)
     updated_at: datetime = Field(default_factory=datetime.utcnow)
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)

--- a/_schema/schemas/groups.py
+++ b/_schema/schemas/groups.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 import uuid
 from datetime import datetime
 from typing import Optional, Dict, Any, List
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 class Group(BaseModel):
     """Represents a GroupMe group managed by the bot for a specific tenant."""
@@ -17,8 +17,7 @@ class Group(BaseModel):
     created_at: datetime = Field(default_factory=datetime.utcnow)
     updated_at: datetime = Field(default_factory=datetime.utcnow)
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)
 
 class GroupChat(BaseModel):
     """Represents a group chat where a bot operates, platform-agnostic."""
@@ -40,5 +39,4 @@ class GroupChat(BaseModel):
     created_at: datetime = Field(default_factory=datetime.utcnow)
     updated_at: datetime = Field(default_factory=datetime.utcnow)
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)

--- a/_schema/schemas/moderation.py
+++ b/_schema/schemas/moderation.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 import uuid
 from datetime import datetime
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 class Infraction(BaseModel):
     """A log of a moderation action taken against a user."""
@@ -17,5 +17,4 @@ class Infraction(BaseModel):
 
     created_at: datetime = Field(default_factory=datetime.utcnow)
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)

--- a/_schema/schemas/monetization.py
+++ b/_schema/schemas/monetization.py
@@ -4,7 +4,7 @@ import uuid
 from datetime import datetime
 from typing import Dict, Any
 from enum import Enum
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 class MonetizationSourceType(str, Enum):
     AFFILIATE_LINK = "affiliate_link"
@@ -45,5 +45,4 @@ class MonetizationSource(BaseModel):
     created_at: datetime = Field(default_factory=datetime.utcnow)
     updated_at: datetime = Field(default_factory=datetime.utcnow)
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)

--- a/_schema/schemas/monetization_advanced.py
+++ b/_schema/schemas/monetization_advanced.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import uuid
 from datetime import datetime
 from typing import Optional, Dict, Any, List
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 class SponsoredContent(BaseModel):
     """Tracks sponsored messages and native advertising campaigns."""
@@ -28,8 +28,7 @@ class SponsoredContent(BaseModel):
     created_at: datetime = Field(default_factory=datetime.utcnow)
     updated_at: datetime = Field(default_factory=datetime.utcnow)
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)
 
 class DataMonetization(BaseModel):
     """Tracks data collection and sales for market research."""
@@ -48,8 +47,7 @@ class DataMonetization(BaseModel):
     revenue_generated: float = Field(..., description="Revenue from this data sale")
     created_at: datetime = Field(default_factory=datetime.utcnow)
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)
 
 class B2BService(BaseModel):
     """Tracks B2B services like lead generation and consulting."""
@@ -70,5 +68,4 @@ class B2BService(BaseModel):
     created_at: datetime = Field(default_factory=datetime.utcnow)
     updated_at: datetime = Field(default_factory=datetime.utcnow)
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)

--- a/_schema/schemas/subscriptions.py
+++ b/_schema/schemas/subscriptions.py
@@ -4,7 +4,7 @@ import uuid
 from datetime import datetime
 from typing import Optional, Dict, Any, List
 from enum import Enum
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 class PlanTier(str, Enum):
     BASIC = "basic"
@@ -37,8 +37,7 @@ class Plan(BaseModel):
     created_at: datetime = Field(default_factory=datetime.utcnow)
     updated_at: datetime = Field(default_factory=datetime.utcnow)
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)
 
 class Subscription(BaseModel):
     """Represents a tenant's active subscription."""
@@ -63,5 +62,4 @@ class Subscription(BaseModel):
     created_at: datetime = Field(default_factory=datetime.utcnow)
     updated_at: datetime = Field(default_factory=datetime.utcnow)
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)

--- a/_schema/schemas/tenants.py
+++ b/_schema/schemas/tenants.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 import uuid
 from datetime import datetime
 from typing import List, Optional
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 class Tenant(BaseModel):
     """Represents a single customer account in the SaaS platform."""
@@ -14,5 +14,4 @@ class Tenant(BaseModel):
     created_at: datetime = Field(default_factory=datetime.utcnow)
     updated_at: datetime = Field(default_factory=datetime.utcnow)
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)

--- a/_schema/schemas/users.py
+++ b/_schema/schemas/users.py
@@ -4,7 +4,7 @@ import uuid
 from datetime import datetime
 from typing import Optional, Dict, Any
 from enum import Enum
-from pydantic import BaseModel, Field, EmailStr
+from pydantic import BaseModel, ConfigDict, EmailStr, Field
 
 class ContactMethod(str, Enum):
     EMAIL = "email"
@@ -91,5 +91,4 @@ class GroupMember(BaseModel):
     created_at: datetime = Field(default_factory=datetime.utcnow)
     updated_at: datetime = Field(default_factory=datetime.utcnow)
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)

--- a/nice-gui/nicegui/__init__.py
+++ b/nice-gui/nicegui/__init__.py
@@ -6,6 +6,25 @@ from __future__ import annotations
 class _DummyUI:
     """Minimal placeholder for the NiceGUI ``ui`` module."""
 
+    def run(
+        self,
+        builder,
+        *,
+        title: str | None = None,
+        host: str = "127.0.0.1",
+        port: int = 8080,
+        **_kwargs,
+    ) -> None:
+        """Invoke ``builder`` and print a helpful stub message."""
+
+        if callable(builder):
+            builder()
+        app_name = title or "NiceGUI Application"
+        print(
+            f"[NiceGUI stub] {app_name} ready. Server would listen on http://{host}:{port}."
+        )
+        print("[NiceGUI stub] This lightweight environment does not start a web server.")
+
     def __getattr__(self, name: str) -> "_DummyUI":
         def _noop(*_args, **_kwargs):  # type: ignore[override]
             return self
@@ -14,6 +33,12 @@ class _DummyUI:
 
     def __call__(self, *_args, **_kwargs) -> "_DummyUI":
         return self
+
+    def __enter__(self) -> "_DummyUI":  # pragma: no cover - trivial
+        return self
+
+    def __exit__(self, *_exc_info) -> None:  # pragma: no cover - trivial
+        return None
 
 
 ui = _DummyUI()

--- a/pydantic/__init__.py
+++ b/pydantic/__init__.py
@@ -29,6 +29,13 @@ if not _real_loaded:
         """Exception raised when data cannot be coerced into the target model."""
 
 
+    class ConfigDict(dict):
+        """Lightweight stand-in mirroring Pydantic's ``ConfigDict``."""
+
+        def __init__(self, **kwargs: Any) -> None:
+            super().__init__(**kwargs)
+
+
     class _Undefined:
         pass
 
@@ -44,19 +51,22 @@ if not _real_loaded:
             default: Any = _UNDEFINED,
             *,
             default_factory: Optional[Callable[[], Any]] = None,
+            **metadata: Any,
         ) -> None:
             self.default = default
             self.default_factory = default_factory
+            self.metadata = metadata
 
 
     def Field(
         default: Any = _UNDEFINED,
         *,
         default_factory: Optional[Callable[[], Any]] = None,
+        **metadata: Any,
     ) -> FieldInfo:
         """Capture default metadata for lazy instantiation."""
 
-        return FieldInfo(default=default, default_factory=default_factory)
+        return FieldInfo(default=default, default_factory=default_factory, **metadata)
 
 
     def validator(*_fields: str, **_kwargs: Any) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
@@ -118,3 +128,7 @@ if not _real_loaded:
         def __repr__(self) -> str:  # pragma: no cover - debugging helper
             fields = ", ".join(f"{k}={v!r}" for k, v in self.dict().items())
             return f"{self.__class__.__name__}({fields})"
+
+    class EmailStr(str):
+        """Minimal stand-in for ``pydantic.EmailStr``."""
+


### PR DESCRIPTION
## Summary
- extend the vendored pydantic compatibility layer with ConfigDict and EmailStr stand-ins to match the updated schemas
- expand the NiceGUI stub so ui.run invokes the builder, prints a helpful message, and supports context manager usage

## Testing
- pytest nice-gui/tests/test_bot_interface.py

------
https://chatgpt.com/codex/tasks/task_e_68e30e8269a083299d0d666b611f13a9