### PR TITLE
Enable real NiceGUI runtime and add startup test

### DIFF
--- a/httpx/__init__.py
+++ b/httpx/__init__.py
@@ -1,23 +1,69 @@
 """Lightweight stub of the httpx client for the test suite."""
 from __future__ import annotations
 
-from typing import Any
+import importlib
+import sys
+from pathlib import Path
 
 
-class AsyncClient:  # type: ignore[too-few-public-methods]
-    """Stub async client mirroring the httpx.AsyncClient interface."""
+def _load_real_httpx():
+    module_name = __name__
+    package_parent = Path(__file__).resolve().parent
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        self._kwargs = kwargs
+    submodule_prefix = f"{module_name}."
+    cached_modules = {
+        name: sys.modules[name]
+        for name in list(sys.modules)
+        if name == module_name or name.startswith(submodule_prefix)
+    }
+    original_sys_path = list(sys.path)
 
-    async def get(self, *args: Any, **kwargs: Any) -> None:
-        raise RuntimeError("httpx.AsyncClient.get not stubbed")
+    try:
+        for name in cached_modules:
+            sys.modules.pop(name, None)
 
-    async def post(self, *args: Any, **kwargs: Any) -> None:
-        raise RuntimeError("httpx.AsyncClient.post not stubbed")
+        sys.path = [
+            entry
+            for entry in original_sys_path
+            if Path(entry).resolve() != package_parent.parent.resolve()
+        ]
 
-    async def aclose(self) -> None:
+        module = importlib.import_module(module_name)
+    except Exception:  # pragma: no cover - falls back to stub
+        sys.modules.update(cached_modules)
         return None
+    else:
+        sys.modules[module_name] = module
+        return module
+    finally:
+        sys.path = original_sys_path
 
 
-__all__ = ["AsyncClient"]
+_REAL_MODULE = _load_real_httpx()
+
+if _REAL_MODULE is not None:
+    __all__ = getattr(_REAL_MODULE, "__all__", [])
+
+    def __getattr__(name: str):  # type: ignore[override]
+        return getattr(_REAL_MODULE, name)
+
+else:
+
+    from typing import Any
+
+    class AsyncClient:  # type: ignore[too-few-public-methods]
+        """Stub async client mirroring the httpx.AsyncClient interface."""
+
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            self._kwargs = kwargs
+
+        async def get(self, *args: Any, **kwargs: Any) -> None:
+            raise RuntimeError("httpx.AsyncClient.get not stubbed")
+
+        async def post(self, *args: Any, **kwargs: Any) -> None:
+            raise RuntimeError("httpx.AsyncClient.post not stubbed")
+
+        async def aclose(self) -> None:
+            return None
+
+    __all__ = ["AsyncClient"]

--- a/nice-gui/main.py
+++ b/nice-gui/main.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 import sys
+from pathlib import Path
 
-from nicegui import ui
+import logging
+import os
+
+from nicegui import app, ui
 
 CURRENT_DIR = Path(__file__).resolve().parent
 if str(CURRENT_DIR) not in sys.path:
@@ -13,21 +16,30 @@ if str(CURRENT_DIR) not in sys.path:
 
 from app import build
 
+PORT = int(os.environ.get("NICEGUI_PORT", "8081"))
+HOST = os.environ.get("NICEGUI_HOST", "127.0.0.1")
 
-import logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("nicegui")
 
-# Enable debug logging for NiceGUI
-logging.basicConfig(level=logging.DEBUG)
-logger = logging.getLogger('nicegui')
 
-try:
-    print('Starting NiceGUI server...')
-    ui.run(build, port=8081, host='127.0.0.1', reload=False)
-    print('Server started on port 8081')
-except Exception as e:
-    print(f'Error: {e}')
-    import traceback
-    traceback.print_exc()
+@app.on_startup
+def _log_startup() -> None:
+    """Announce that the NiceGUI server finished booting."""
 
-# Keep the server running
-input('Server is running on http://localhost:8081. Press Enter to stop...')
+    logger.info("NiceGUI server is ready at http://%s:%s", HOST, PORT)
+
+
+def main() -> None:
+    """Launch the NiceGUI application."""
+
+    logger.info("Starting NiceGUI server on %s:%s", HOST, PORT)
+    ui.run(build, port=PORT, host=HOST, reload=False, show=False)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception:
+        logger.exception("NiceGUI failed to start")
+        raise

--- a/nice-gui/nicegui/__init__.py
+++ b/nice-gui/nicegui/__init__.py
@@ -1,21 +1,72 @@
-"""Lightweight NiceGUI compatibility layer for test execution."""
+"""NiceGUI compatibility layer that prefers the real package when available."""
 
 from __future__ import annotations
 
+import importlib
+import sys
+from pathlib import Path
+from typing import Any
 
-class _DummyUI:
-    """Minimal placeholder for the NiceGUI ``ui`` module."""
 
-    def __getattr__(self, name: str) -> "_DummyUI":
-        def _noop(*_args, **_kwargs):  # type: ignore[override]
+def _load_real_nicegui():
+    """Attempt to load the installed NiceGUI distribution."""
+
+    module_name = __name__
+    package_parent = Path(__file__).resolve().parents[1]
+
+    submodule_prefix = f"{module_name}."
+    cached_modules = {
+        name: sys.modules[name]
+        for name in list(sys.modules)
+        if name == module_name or name.startswith(submodule_prefix)
+    }
+    original_sys_path = list(sys.path)
+
+    try:
+        for name in cached_modules:
+            sys.modules.pop(name, None)
+
+        sys.path = [
+            entry
+            for entry in original_sys_path
+            if Path(entry).resolve() != package_parent.resolve()
+        ]
+
+        module = importlib.import_module(module_name)
+    except Exception:  # pragma: no cover - falls back to stub
+        sys.modules.update(cached_modules)
+        return None
+    else:
+        sys.modules[module_name] = module
+        return module
+    finally:
+        sys.path = original_sys_path
+
+
+_REAL_MODULE = _load_real_nicegui()
+
+if _REAL_MODULE is not None:
+    ui = _REAL_MODULE.ui  # type: ignore[attr-defined]
+    __all__ = getattr(_REAL_MODULE, "__all__", ["ui"])
+
+    def __getattr__(name: str) -> Any:  # noqa: D401
+        """Proxy missing attributes to the real NiceGUI module."""
+
+        return getattr(_REAL_MODULE, name)
+
+else:
+
+    class _DummyUI:
+        """Minimal placeholder for the NiceGUI ``ui`` module."""
+
+        def __getattr__(self, name: str) -> "_DummyUI":
+            def _noop(*_args, **_kwargs):  # type: ignore[override]
+                return self
+
+            return _noop
+
+        def __call__(self, *_args, **_kwargs) -> "_DummyUI":
             return self
 
-        return _noop
-
-    def __call__(self, *_args, **_kwargs) -> "_DummyUI":
-        return self
-
-
-ui = _DummyUI()
-
-__all__ = ["ui"]
+    ui = _DummyUI()
+    __all__ = ["ui"]

--- a/nice-gui/tests/test_server_startup.py
+++ b/nice-gui/tests/test_server_startup.py
@@ -1,0 +1,104 @@
+"""Ensure the NiceGUI application boots a live HTTP server."""
+
+from __future__ import annotations
+
+import os
+import socket
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+from typing import Optional
+
+import httpx
+import pytest
+
+from nicegui import ui
+
+
+if ui.__class__.__name__ == "_DummyUI":  # pragma: no cover - fallback stub
+    pytest.skip("NiceGUI stub is active; skipping server startup test.", allow_module_level=True)
+
+
+def _get_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def test_nicegui_server_responds(tmp_path: Path) -> None:
+    """The dashboard should become reachable over HTTP once started."""
+
+    port = _get_free_port()
+    project_root = Path(__file__).resolve().parents[1]
+    main_script = project_root / "main.py"
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "NICEGUI_PORT": str(port),
+            "NICEGUI_HOST": "127.0.0.1",
+            "PYTHONUNBUFFERED": "1",
+            "NICEGUI_SCREEN_TEST_PORT": str(port),
+        }
+    )
+
+    process = subprocess.Popen(
+        [sys.executable, str(main_script)],
+        cwd=str(project_root),
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+
+    output_lines: list[str] = []
+
+    def _drain_stdout() -> None:
+        assert process.stdout is not None
+        for line in process.stdout:
+            output_lines.append(line)
+
+    reader = threading.Thread(target=_drain_stdout, daemon=True)
+    reader.start()
+
+    response: Optional[httpx.Response] = None
+    deadline = time.time() + 45
+    url = f"http://127.0.0.1:{port}"
+
+    try:
+        while time.time() < deadline:
+            if process.poll() is not None:
+                reader.join(timeout=2)
+                pytest.fail(
+                    "NiceGUI process exited early with code"
+                    f" {process.returncode}: {''.join(output_lines)}"
+                )
+
+            try:
+                response = httpx.get(url, timeout=1.0)
+            except httpx.RequestError:
+                time.sleep(0.5)
+                continue
+
+            if response.status_code < 500:
+                break
+            time.sleep(0.5)
+        else:
+            reader.join(timeout=2)
+            pytest.fail(
+                "NiceGUI server did not become reachable in time. Output:\n"
+                + "".join(output_lines)
+            )
+    finally:
+        process.terminate()
+        try:
+            process.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait()
+        reader.join(timeout=2)
+
+    assert response is not None
+    assert response.status_code == 200

--- a/pydantic/__init__.py
+++ b/pydantic/__init__.py
@@ -44,19 +44,37 @@ if not _real_loaded:
             default: Any = _UNDEFINED,
             *,
             default_factory: Optional[Callable[[], Any]] = None,
+            metadata: Optional[Dict[str, Any]] = None,
         ) -> None:
             self.default = default
             self.default_factory = default_factory
+            self.metadata = metadata or {}
 
 
     def Field(
         default: Any = _UNDEFINED,
         *,
         default_factory: Optional[Callable[[], Any]] = None,
+        **metadata: Any,
     ) -> FieldInfo:
         """Capture default metadata for lazy instantiation."""
 
-        return FieldInfo(default=default, default_factory=default_factory)
+        return FieldInfo(
+            default=default,
+            default_factory=default_factory,
+            metadata=dict(metadata),
+        )
+
+
+    class EmailStr(str):
+        """Fallback type representing validated email strings."""
+
+
+    class ConfigDict(dict):
+        """Lightweight stand-in for :class:`pydantic.ConfigDict`."""
+
+        def __init__(self, **kwargs: Any) -> None:
+            super().__init__(**kwargs)
 
 
     def validator(*_fields: str, **_kwargs: Any) -> Callable[[Callable[..., Any]], Callable[..., Any]]:

--- a/websockets/__init__.py
+++ b/websockets/__init__.py
@@ -1,19 +1,68 @@
-"""Minimal stub of :mod:`websockets` for offline tests."""
+"""Minimal stub of :mod:`websockets` with passthrough to the real package."""
 from __future__ import annotations
 
+import importlib
+import sys
+from pathlib import Path
 from typing import Any
 
 from .exceptions import ConnectionClosed
 
 
-class WebSocketServerProtocol:
-    """Placeholder websocket protocol."""
+def _load_real_websockets():
+    """Load the external :mod:`websockets` distribution when it is installed."""
 
-    async def send(self, *args: Any, **kwargs: Any) -> None:
-        raise NotImplementedError
+    module_name = __name__
+    package_parent = Path(__file__).resolve().parent.parent
 
-    async def recv(self) -> Any:
-        raise NotImplementedError
+    submodule_prefix = f"{module_name}."
+    cached_modules = {
+        name: sys.modules[name]
+        for name in list(sys.modules)
+        if name == module_name or name.startswith(submodule_prefix)
+    }
+    original_sys_path = list(sys.path)
+
+    try:
+        for name in cached_modules:
+            sys.modules.pop(name, None)
+
+        sys.path = [
+            entry
+            for entry in original_sys_path
+            if Path(entry).resolve() != package_parent.resolve()
+        ]
+
+        module = importlib.import_module(module_name)
+    except Exception:  # pragma: no cover - falls back to stub
+        sys.modules.update(cached_modules)
+        return None
+    else:
+        sys.modules[module_name] = module
+        return module
+    finally:
+        sys.path = original_sys_path
 
 
-__all__ = ["WebSocketServerProtocol", "ConnectionClosed"]
+_REAL_MODULE = _load_real_websockets()
+
+if _REAL_MODULE is not None:
+    __all__ = getattr(_REAL_MODULE, "__all__", [])
+
+    def __getattr__(name: str) -> Any:
+        return getattr(_REAL_MODULE, name)
+
+    ConnectionClosed = getattr(_REAL_MODULE, "ConnectionClosed", ConnectionClosed)
+
+else:
+
+    class WebSocketServerProtocol:
+        """Placeholder websocket protocol."""
+
+        async def send(self, *args: Any, **kwargs: Any) -> None:
+            raise NotImplementedError
+
+        async def recv(self) -> Any:
+            raise NotImplementedError
+
+    __all__ = ["WebSocketServerProtocol", "ConnectionClosed"]


### PR DESCRIPTION
## Summary
- allow the local nicegui, websockets, and httpx shims to delegate to the installed packages when available
- update the NiceGUI entrypoint to use configurable host/port settings and log readiness via FastAPI startup hooks
- add an integration test that launches the NiceGUI app in a subprocess and verifies the HTTP endpoint responds

## Testing
- pytest nice-gui/tests/test_server_startup.py -rs

------
https://chatgpt.com/codex/tasks/task_e_68e31cb0b5248329b5087eb3e81d9fd7