### PR TITLE
Add workflow metadata for Telegram and Discord

### DIFF
--- a/app/discord/workflows/base.py
+++ b/app/discord/workflows/base.py
@@ -39,6 +39,8 @@ class WorkflowDefinition:
     """Base class for all orchestrated workflows."""
 
     name: str
+    title: str
+    description: str
     goal: str
     kpis: Sequence[WorkflowKPI]
 

--- a/app/discord/workflows/commerce_workflows.py
+++ b/app/discord/workflows/commerce_workflows.py
@@ -15,6 +15,8 @@ __all__ = [
 class CommerceIntentWorkflow(WorkflowDefinition):
     """Detect commerce intents for downstream monetization workflows in Discord."""
 
+    title = "Discord Commerce Intent"
+    description = "Identify purchase-ready conversations to activate monetization playbooks."
     name = "discord_commerce_intent_detection"
     goal = "Maintain commerce intent precision above 0.8 with efficient processing."
     kpis = (

--- a/app/discord/workflows/data_management_workflows.py
+++ b/app/discord/workflows/data_management_workflows.py
@@ -17,6 +17,8 @@ __all__ = [
 class DataBackupWorkflow(WorkflowDefinition):
     """Automated backup of Discord server data."""
 
+    title = "Discord Data Backup"
+    description = "Capture resilient snapshots of Discord channels, roles, and metadata."
     name = "discord_data_backup"
     goal = "Ensure 100% of critical server data is backed up regularly."
     kpis = (
@@ -107,6 +109,8 @@ class DataBackupWorkflow(WorkflowDefinition):
 class DataCleanupWorkflow(WorkflowDefinition):
     """Automated cleanup of old or unnecessary Discord data."""
 
+    title = "Discord Data Cleanup"
+    description = "Purge outdated channels, bot messages, and unused assets to improve signal quality."
     name = "discord_data_cleanup"
     goal = "Maintain optimal server performance by cleaning up old data."
     kpis = (
@@ -188,6 +192,8 @@ class DataCleanupWorkflow(WorkflowDefinition):
 class DataMigrationWorkflow(WorkflowDefinition):
     """Migrate data between Discord servers or platforms."""
 
+    title = "Discord Data Migration"
+    description = "Transfer guild configuration and artifacts safely between Discord servers."
     name = "discord_data_migration"
     goal = "Successfully migrate server data with zero data loss."
     kpis = (

--- a/app/discord/workflows/engagement_workflows.py
+++ b/app/discord/workflows/engagement_workflows.py
@@ -18,6 +18,8 @@ __all__ = [
 class AutoLikeFeedbackWorkflow(WorkflowDefinition):
     """Close the feedback loop by reacting to high-value messages in Discord."""
 
+    title = "Discord Auto-Like Feedback"
+    description = "React to high-signal messages to encourage ongoing community engagement."
     name = "discord_auto_like_feedback"
     goal = "Acknowledge high-value messages with bot reactions to boost engagement."
     kpis = (
@@ -64,6 +66,8 @@ class AutoLikeFeedbackWorkflow(WorkflowDefinition):
 class ContentQualityRelevanceWorkflow(WorkflowDefinition):
     """Assess and promote high-quality, relevant content in Discord channels."""
 
+    title = "Discord Content Quality & Relevance"
+    description = "Surface high-signal content and promote it across the Discord community."
     name = "discord_content_quality_relevance"
     goal = "Identify and highlight 90% of high-quality messages for better community experience."
     kpis = (
@@ -141,6 +145,8 @@ class ContentQualityRelevanceWorkflow(WorkflowDefinition):
 class AutomatedCustomerSupportWorkflow(WorkflowDefinition):
     """Provide automated support responses for common queries in Discord."""
 
+    title = "Discord Automated Customer Support"
+    description = "Handle repetitive support questions with automated Discord responses."
     name = "discord_automated_customer_support"
     goal = "Resolve 80% of common support queries automatically within Discord channels."
     kpis = (
@@ -211,6 +217,8 @@ class AutomatedCustomerSupportWorkflow(WorkflowDefinition):
 class EmergencyResponseWorkflow(WorkflowDefinition):
     """Handle emergency situations and critical alerts in Discord."""
 
+    title = "Discord Emergency Response"
+    description = "Detect critical incidents in Discord channels and trigger rapid response workflows."
     name = "discord_emergency_response"
     goal = "Respond to 100% of emergency situations within 2 minutes."
     kpis = (

--- a/app/discord/workflows/growth_workflows.py
+++ b/app/discord/workflows/growth_workflows.py
@@ -16,6 +16,8 @@ __all__ = [
 class GhostInvitationWorkflow(WorkflowDefinition):
     """Generate dynamic share links for stealth invitations in Discord."""
 
+    title = "Discord Ghost Invitations"
+    description = "Create campaign-ready invite links for targeted community growth."
     name = "discord_ghost_invitation_share_links"
     goal = "Generate at least 3 valid invite links for growth campaigns."
     kpis = (
@@ -76,6 +78,8 @@ class GhostInvitationWorkflow(WorkflowDefinition):
 class ServerGrowthWorkflow(WorkflowDefinition):
     """Monitor and optimize server growth metrics."""
 
+    title = "Discord Server Growth"
+    description = "Track membership momentum and retention signals across the Discord server."
     name = "discord_server_growth_monitoring"
     goal = "Achieve consistent server growth with positive member retention."
     kpis = (

--- a/app/discord/workflows/media_processing_workflows.py
+++ b/app/discord/workflows/media_processing_workflows.py
@@ -18,6 +18,8 @@ __all__ = [
 class MediaProcessingWorkflow(WorkflowDefinition):
     """Comprehensive media processing for Discord server content."""
 
+    title = "Discord Media Processing"
+    description = "Process, classify, and respond to media shared across Discord channels."
     name = "discord_media_processing"
     goal = "Process and optimize all media content for better user experience."
     kpis = (
@@ -113,6 +115,8 @@ class MediaProcessingWorkflow(WorkflowDefinition):
 class ImageOptimizationWorkflow(WorkflowDefinition):
     """Optimize images for Discord's file size limits and performance."""
 
+    title = "Discord Image Optimization"
+    description = "Optimize large Discord images to meet delivery limits without losing fidelity."
     name = "discord_image_optimization"
     goal = "Optimize all images to meet Discord's requirements while maintaining quality."
     kpis = (
@@ -175,6 +179,8 @@ class ImageOptimizationWorkflow(WorkflowDefinition):
 class VideoProcessingWorkflow(WorkflowDefinition):
     """Process and optimize video content for Discord."""
 
+    title = "Discord Video Processing"
+    description = "Transcode and compress Discord video uploads for smooth playback."
     name = "discord_video_processing"
     goal = "Ensure all videos are properly formatted and optimized for Discord playback."
     kpis = (
@@ -236,6 +242,8 @@ class VideoProcessingWorkflow(WorkflowDefinition):
 class FileUploadWorkflow(WorkflowDefinition):
     """Manage and optimize file uploads in Discord channels."""
 
+    title = "Discord File Upload Management"
+    description = "Coordinate chunked uploads and recovery paths for large Discord file transfers."
     name = "discord_file_upload_management"
     goal = "Ensure all file uploads are properly managed and optimized."
     kpis = (

--- a/app/discord/workflows/member_management_workflows.py
+++ b/app/discord/workflows/member_management_workflows.py
@@ -18,6 +18,8 @@ __all__ = [
 class MemberManagementWorkflow(WorkflowDefinition):
     """Comprehensive member management for Discord server."""
 
+    title = "Discord Member Management"
+    description = "Coordinate onboarding, verification, and cleanup tasks for Discord members."
     name = "discord_member_management"
     goal = "Maintain healthy server membership with proper management tools."
     kpis = (
@@ -91,6 +93,8 @@ class MemberManagementWorkflow(WorkflowDefinition):
 class RoleManagementWorkflow(WorkflowDefinition):
     """Automated role management and assignment for Discord members."""
 
+    title = "Discord Role Management"
+    description = "Audit and correct Discord role assignments to maintain hierarchy integrity."
     name = "discord_role_management"
     goal = "Ensure proper role assignment and hierarchy management."
     kpis = (
@@ -153,6 +157,8 @@ class RoleManagementWorkflow(WorkflowDefinition):
 class MemberOnboardingWorkflow(WorkflowDefinition):
     """Automate the onboarding process for new Discord members."""
 
+    title = "Discord Member Onboarding"
+    description = "Guide new members through welcome, rules, and verification flows."
     name = "discord_member_onboarding"
     goal = "Ensure smooth onboarding experience for all new members."
     kpis = (
@@ -218,6 +224,8 @@ class MemberOnboardingWorkflow(WorkflowDefinition):
 class MemberRetentionWorkflow(WorkflowDefinition):
     """Monitor and improve member retention in Discord server."""
 
+    title = "Discord Member Retention"
+    description = "Measure churn risk and trigger engagement nudges to retain members."
     name = "discord_member_retention"
     goal = "Maintain high member retention through engagement and support."
     kpis = (

--- a/app/discord/workflows/message_stitching_workflow.py
+++ b/app/discord/workflows/message_stitching_workflow.py
@@ -18,6 +18,8 @@ from .base import WorkflowDefinition, WorkflowContext, WorkflowKPI, WorkflowResu
 class MessageStitchingWorkflow(WorkflowDefinition):
     """Workflow for stitching messages together based on patterns."""
 
+    title = "Discord Message Stitching Engine"
+    description = "Aggregate related Discord messages and deliver stitched summaries back to the channel."
     name = "discord_message_stitching"
     goal = "Stitch related messages in Discord channels to improve conversation flow."
     kpis = (

--- a/app/discord/workflows/message_workflows.py
+++ b/app/discord/workflows/message_workflows.py
@@ -17,6 +17,8 @@ __all__ = [
 class MessageStitchingWorkflow(WorkflowDefinition):
     """Stitch and echo high-engagement content across Discord channels."""
 
+    title = "Discord Message Stitching"
+    description = "Stitch related Discord messages and rebroadcast highlights across communities."
     name = "discord_message_stitching_content_echo"
     goal = "Amplify cross-channel engagement by echoing at least 5 high-signal messages per run."
     kpis = (
@@ -75,6 +77,8 @@ class MessageStitchingWorkflow(WorkflowDefinition):
 class SecurityModerationWorkflow(WorkflowDefinition):
     """Monitors for spam, inappropriate content, or policy violations in Discord channels."""
 
+    title = "Discord Security Moderation"
+    description = "Detect and escalate potential policy violations within Discord channels."
     name = "discord_security_moderation_monitoring"
     goal = "Detect and flag 95% of inappropriate content within 5 minutes."
     kpis = (
@@ -125,6 +129,8 @@ class SecurityModerationWorkflow(WorkflowDefinition):
 class ContentEchoWorkflow(WorkflowDefinition):
     """Echo and share engaging content across Discord channels."""
 
+    title = "Discord Content Echo"
+    description = "Amplify standout Discord conversations by echoing them to target communities."
     name = "discord_content_echo"
     goal = "Share high-engagement content across channels to boost overall activity."
     kpis = (

--- a/app/discord/workflows/notification_workflows.py
+++ b/app/discord/workflows/notification_workflows.py
@@ -19,6 +19,8 @@ __all__ = [
 class NotificationWorkflow(WorkflowDefinition):
     """Comprehensive notification system for Discord server events."""
 
+    title = "Discord Notification System"
+    description = "Distribute lifecycle notifications across Discord channels and cohorts."
     name = "discord_notification_system"
     goal = "Deliver timely and relevant notifications to all server members."
     kpis = (
@@ -87,6 +89,8 @@ class NotificationWorkflow(WorkflowDefinition):
 class ScheduledMessagingWorkflow(WorkflowDefinition):
     """Schedule and automate message delivery in Discord channels."""
 
+    title = "Discord Scheduled Messaging"
+    description = "Automate recurring Discord announcements with reliable scheduling."
     name = "discord_scheduled_messaging"
     goal = "Deliver scheduled messages with perfect timing and reliability."
     kpis = (
@@ -146,6 +150,8 @@ class ScheduledMessagingWorkflow(WorkflowDefinition):
 class AnnouncementWorkflow(WorkflowDefinition):
     """Create and distribute announcements across Discord server."""
 
+    title = "Discord Announcement Distribution"
+    description = "Deliver announcements to targeted Discord channels with measurable reach."
     name = "discord_announcement_distribution"
     goal = "Ensure all important announcements reach maximum audience."
     kpis = (
@@ -216,6 +222,8 @@ class AnnouncementWorkflow(WorkflowDefinition):
 class ReminderWorkflow(WorkflowDefinition):
     """Set up and manage reminders for Discord server members."""
 
+    title = "Discord Reminder System"
+    description = "Orchestrate event, task, and deadline reminders to keep members engaged."
     name = "discord_reminder_system"
     goal = "Deliver timely reminders to improve member engagement and retention."
     kpis = (

--- a/app/discord/workflows/tests/test_discord_workflows.py
+++ b/app/discord/workflows/tests/test_discord_workflows.py
@@ -7,9 +7,16 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 import discord
-from discord.ext import commands
 
-from workflows.base import WorkflowContext
+if not hasattr(discord, "Message"):
+    class _StubMessage:  # pragma: no cover - shim for tests
+        """Lightweight stand-in for discord.Message when unavailable."""
+
+        pass
+
+    discord.Message = _StubMessage  # type: ignore[attr-defined]
+
+from workflows.base import WorkflowContext, WorkflowKPI
 from workflows.commerce_workflows import CommerceIntentWorkflow
 from workflows.growth_workflows import GhostInvitationWorkflow, ServerGrowthWorkflow
 from workflows.tracking_workflows import RealTimeSubscriptionWorkflow, AnalyticsWorkflow, MessageAnalyticsWorkflow
@@ -17,6 +24,67 @@ from workflows.data_management_workflows import DataBackupWorkflow, DataCleanupW
 from workflows.media_processing_workflows import MediaProcessingWorkflow, ImageOptimizationWorkflow, VideoProcessingWorkflow, FileUploadWorkflow
 from workflows.member_management_workflows import MemberManagementWorkflow, RoleManagementWorkflow, MemberOnboardingWorkflow, MemberRetentionWorkflow
 from workflows.notification_workflows import NotificationWorkflow, ScheduledMessagingWorkflow, AnnouncementWorkflow, ReminderWorkflow
+from workflows.message_workflows import (
+    MessageStitchingWorkflow as ContentEchoStitchWorkflow,
+    SecurityModerationWorkflow,
+    ContentEchoWorkflow,
+)
+from workflows.engagement_workflows import (
+    AutoLikeFeedbackWorkflow,
+    ContentQualityRelevanceWorkflow,
+    AutomatedCustomerSupportWorkflow,
+    EmergencyResponseWorkflow,
+)
+
+
+def _assert_workflow_metadata(workflow):
+    assert isinstance(workflow.title, str) and workflow.title.strip()
+    assert isinstance(workflow.description, str) and workflow.description.strip()
+    assert isinstance(workflow.goal, str) and workflow.goal.strip()
+    assert isinstance(workflow.kpis, (list, tuple)) and workflow.kpis
+    for kpi in workflow.kpis:
+        assert isinstance(kpi, WorkflowKPI)
+        assert kpi.name.strip()
+        assert kpi.target.strip()
+        assert kpi.description.strip()
+
+
+def test_discord_workflows_include_metadata():
+    """Every Discord workflow should expose descriptive metadata."""
+
+    workflows = [
+        CommerceIntentWorkflow(),
+        GhostInvitationWorkflow(),
+        ServerGrowthWorkflow(),
+        RealTimeSubscriptionWorkflow(),
+        AnalyticsWorkflow(),
+        MessageAnalyticsWorkflow(),
+        DataBackupWorkflow(),
+        DataCleanupWorkflow(),
+        DataMigrationWorkflow(),
+        MediaProcessingWorkflow(),
+        ImageOptimizationWorkflow(),
+        VideoProcessingWorkflow(),
+        FileUploadWorkflow(),
+        MemberManagementWorkflow(),
+        RoleManagementWorkflow(),
+        MemberOnboardingWorkflow(),
+        MemberRetentionWorkflow(),
+        NotificationWorkflow(),
+        ScheduledMessagingWorkflow(),
+        AnnouncementWorkflow(),
+        ReminderWorkflow(),
+        ContentEchoStitchWorkflow(),
+        SecurityModerationWorkflow(),
+        ContentEchoWorkflow(),
+        AutoLikeFeedbackWorkflow(),
+        ContentQualityRelevanceWorkflow(),
+        AutomatedCustomerSupportWorkflow(),
+        EmergencyResponseWorkflow(),
+    ]
+
+    for workflow in workflows:
+        _assert_workflow_metadata(workflow)
 
 
 class TestCommerceWorkflows:

--- a/app/discord/workflows/tracking_workflows.py
+++ b/app/discord/workflows/tracking_workflows.py
@@ -18,6 +18,8 @@ __all__ = [
 class RealTimeSubscriptionWorkflow(WorkflowDefinition):
     """Real-time event capture for Discord server monitoring."""
 
+    title = "Discord Real-Time Subscription"
+    description = "Capture live Discord channel activity and forward enriched events to analytics workers."
     name = "discord_real_time_subscription_monitoring"
     goal = "Capture 100% of real-time events with minimal latency."
     kpis = (
@@ -85,6 +87,8 @@ class RealTimeSubscriptionWorkflow(WorkflowDefinition):
 class AnalyticsWorkflow(WorkflowDefinition):
     """Comprehensive analytics collection for Discord server."""
 
+    title = "Discord Analytics Collection"
+    description = "Aggregate multi-signal analytics across guild membership, messaging, and reactions."
     name = "discord_analytics_collection"
     goal = "Collect comprehensive analytics data across all server activities."
     kpis = (
@@ -162,6 +166,8 @@ class AnalyticsWorkflow(WorkflowDefinition):
 class MessageAnalyticsWorkflow(WorkflowDefinition):
     """Detailed message analytics and engagement tracking."""
 
+    title = "Discord Message Analytics"
+    description = "Deliver deep engagement insights by analyzing Discord message sentiment and reactions."
     name = "discord_message_analytics"
     goal = "Provide detailed insights into message patterns and engagement."
     kpis = (

--- a/app/discord/workflows/workflow_suite.py
+++ b/app/discord/workflows/workflow_suite.py
@@ -170,6 +170,8 @@ class DiscordWorkflowSuite:
         workflow = self.workflows[workflow_name]
         return {
             'name': workflow.name,
+            'title': workflow.title,
+            'description': workflow.description,
             'goal': workflow.goal,
             'kpis': [kpi.__dict__ for kpi in workflow.kpis],
         }

--- a/app/telegram/workflows/adaptive_frequency_workflow.py
+++ b/app/telegram/workflows/adaptive_frequency_workflow.py
@@ -14,6 +14,27 @@ from app.telegram.api.telegram_api import TelegramBotAPI, Update, Message
 class AdaptiveFrequencyWorkflow:
     """Workflow for adapting message frequency based on chat activity."""
 
+    title = "Telegram Adaptive Frequency"
+    description = "Continuously tune outbound messaging cadence in response to chat activity levels."
+    goal = "Maintain the optimal engagement cadence by adapting send intervals to observed message volume."
+    kpis = [
+        {
+            "name": "interval_adjustments",
+            "target": ">=1/run",
+            "description": "Number of cadence adjustments applied during a workflow execution.",
+        },
+        {
+            "name": "messages_tracked",
+            "target": ">=20",
+            "description": "Count of incoming messages evaluated for frequency decisions.",
+        },
+        {
+            "name": "overactivity_alert_rate",
+            "target": "<=10%",
+            "description": "Percentage of runs where activity exceeds configured thresholds without adjustment.",
+        },
+    ]
+
     def __init__(self, bot: TelegramBotAPI, base_interval: int = 60, max_interval: int = 300, min_interval: int = 10):
         self.bot = bot
         self.base_interval = base_interval  # Base time between messages (seconds)

--- a/app/telegram/workflows/auto_like_feedback_workflow.py
+++ b/app/telegram/workflows/auto_like_feedback_workflow.py
@@ -14,6 +14,27 @@ from app.telegram.api.telegram_api import TelegramBotAPI, Update, Message
 class AutoLikeFeedbackWorkflow:
     """Workflow for automatic liking and feedback on messages."""
 
+    title = "Telegram Auto-Like Feedback"
+    description = "React to positive conversations and acknowledge community feedback automatically."
+    goal = "Surface appreciation and maintain conversational momentum by engaging with high-sentiment messages."
+    kpis = [
+        {
+            "name": "positive_feedback_responses",
+            "target": ">=80%",
+            "description": "Share of positive sentiment messages that receive a tailored response.",
+        },
+        {
+            "name": "reaction_rate",
+            "target": ">=30%",
+            "description": "Percentage of processed messages that receive an emoji reaction.",
+        },
+        {
+            "name": "duplicate_processing_rate",
+            "target": "<=1%",
+            "description": "Rate of duplicate message handling due to idempotency issues.",
+        },
+    ]
+
     def __init__(self, bot: TelegramBotAPI, like_probability: float = 0.3, feedback_keywords: Optional[List[str]] = None):
         self.bot = bot
         self.like_probability = like_probability  # Probability to "like" (react) to messages

--- a/app/telegram/workflows/integration_workflows.py
+++ b/app/telegram/workflows/integration_workflows.py
@@ -58,6 +58,19 @@ class IntegrationWorkflows:
                 stats[name] = workflow.get_stitch_stats()
         return stats
 
+    def get_workflow_metadata(self) -> Dict[str, Dict[str, Any]]:
+        """Expose descriptive metadata for each registered workflow."""
+
+        metadata: Dict[str, Dict[str, Any]] = {}
+        for name, workflow in self.workflows.items():
+            metadata[name] = {
+                'title': getattr(workflow, 'title', ''),
+                'description': getattr(workflow, 'description', ''),
+                'goal': getattr(workflow, 'goal', ''),
+                'kpis': getattr(workflow, 'kpis', []),
+            }
+        return metadata
+
     def enable_workflow(self, workflow_name: str) -> bool:
         """Enable a specific workflow."""
         if workflow_name in self.workflows:

--- a/app/telegram/workflows/media_processing_workflow.py
+++ b/app/telegram/workflows/media_processing_workflow.py
@@ -12,6 +12,27 @@ from app.telegram.api.telegram_api import TelegramBotAPI, Update, Message
 class MediaProcessingWorkflow:
     """Workflow for processing media messages."""
 
+    title = "Telegram Media Processing"
+    description = "Detect, acknowledge, and optionally echo media shared with the Telegram bot."
+    goal = "Classify inbound media assets and provide timely confirmations or follow-up actions."
+    kpis = [
+        {
+            "name": "media_messages_processed",
+            "target": ">=10/run",
+            "description": "Number of media messages analyzed during a workflow execution.",
+        },
+        {
+            "name": "acknowledgement_rate",
+            "target": ">=95%",
+            "description": "Percentage of media uploads that receive an acknowledgement message.",
+        },
+        {
+            "name": "processing_error_rate",
+            "target": "<=5%",
+            "description": "Share of media interactions that fail due to processing errors.",
+        },
+    ]
+
     def __init__(self, bot: TelegramBotAPI):
         self.bot = bot
         self.media_handlers = {

--- a/app/telegram/workflows/member_management_workflow.py
+++ b/app/telegram/workflows/member_management_workflow.py
@@ -6,12 +6,33 @@ like ban, unban, promote, etc.
 """
 
 import time
-from typing import Dict, Any, List
+from typing import Any, Dict, List, Optional
 from app.telegram.api.telegram_api import TelegramBotAPI, Update, Message
 
 
 class MemberManagementWorkflow:
     """Workflow for managing chat members."""
+
+    title = "Telegram Member Management"
+    description = "Automate moderation actions such as ban, unban, promote, and demote within Telegram chats."
+    goal = "Ensure administrative actions are executed reliably while notifying operators of outcomes."
+    kpis = [
+        {
+            "name": "admin_actions_processed",
+            "target": ">=5/day",
+            "description": "Number of moderation commands successfully executed each day.",
+        },
+        {
+            "name": "action_success_rate",
+            "target": ">=95%",
+            "description": "Share of administrative commands that complete without errors.",
+        },
+        {
+            "name": "response_latency",
+            "target": "<5s",
+            "description": "Average time to acknowledge a moderation command in chat.",
+        },
+    ]
 
     def __init__(self, bot: TelegramBotAPI):
         self.bot = bot

--- a/app/telegram/workflows/message_handling_workflow.py
+++ b/app/telegram/workflows/message_handling_workflow.py
@@ -13,6 +13,27 @@ from app.telegram.api.telegram_api import TelegramBotAPI, Update, Message
 class MessageHandlingWorkflow:
     """Workflow for processing and responding to messages."""
 
+    title = "Telegram Message Handling"
+    description = "Route inbound Telegram messages to the right command handlers with contextual replies."
+    goal = "Respond to recognized commands and keywords with actionable guidance within seconds."
+    kpis = [
+        {
+            "name": "commands_handled",
+            "target": ">=90%",
+            "description": "Percentage of recognized commands receiving an automated response.",
+        },
+        {
+            "name": "average_response_latency",
+            "target": "<3s",
+            "description": "Average time taken to send a response after receiving a message.",
+        },
+        {
+            "name": "fallback_rate",
+            "target": "<10%",
+            "description": "Share of messages that route to the default handler due to no match.",
+        },
+    ]
+
     def __init__(self, bot: TelegramBotAPI):
         self.bot = bot
         self.handlers = {

--- a/app/telegram/workflows/message_stitching_workflow.py
+++ b/app/telegram/workflows/message_stitching_workflow.py
@@ -15,6 +15,27 @@ from app.telegram.api.telegram_api import TelegramBotAPI, Update, Message
 class MessageStitchingWorkflow:
     """Workflow for stitching messages together based on patterns."""
 
+    title = "Telegram Message Stitching"
+    description = "Aggregate related Telegram messages into cohesive summaries for easier consumption."
+    goal = "Combine contextual message sequences into stitched updates before notifying the chat."
+    kpis = [
+        {
+            "name": "stitched_threads",
+            "target": ">=1/run",
+            "description": "Number of message groups successfully combined during processing.",
+        },
+        {
+            "name": "average_stitch_size",
+            "target": "3-5 messages",
+            "description": "Average count of individual messages merged per stitched output.",
+        },
+        {
+            "name": "stitch_success_rate",
+            "target": ">=85%",
+            "description": "Share of detected threads that produce a stitched message without errors.",
+        },
+    ]
+
     def __init__(self, bot: TelegramBotAPI, stitch_timeout: int = 300, max_stitch_length: int = 5):
         self.bot = bot
         self.stitch_timeout = stitch_timeout  # Seconds to wait before stitching

--- a/app/telegram/workflows/scheduled_messaging_workflow.py
+++ b/app/telegram/workflows/scheduled_messaging_workflow.py
@@ -14,6 +14,27 @@ from app.telegram.api.telegram_api import TelegramBotAPI, Message
 class ScheduledMessagingWorkflow:
     """Workflow for sending scheduled messages."""
 
+    title = "Telegram Scheduled Messaging"
+    description = "Plan, queue, and dispatch reminders or broadcasts at precise intervals via Telegram."
+    goal = "Deliver scheduled and recurring Telegram messages at the requested time without manual intervention."
+    kpis = [
+        {
+            "name": "scheduled_messages_sent",
+            "target": ">=1/run",
+            "description": "Count of queued messages that were successfully delivered during a run.",
+        },
+        {
+            "name": "on_time_delivery_rate",
+            "target": ">=95%",
+            "description": "Share of scheduled messages delivered within the expected time window.",
+        },
+        {
+            "name": "pending_queue_depth",
+            "target": "<=3",
+            "description": "Number of overdue scheduled messages awaiting dispatch.",
+        },
+    ]
+
     def __init__(self, bot: TelegramBotAPI):
         self.bot = bot
         self.scheduled_messages: List[Dict[str, Any]] = []

--- a/app/telegram/workflows/tests/test_workflow_metadata.py
+++ b/app/telegram/workflows/tests/test_workflow_metadata.py
@@ -1,0 +1,42 @@
+"""Metadata coverage tests for Telegram workflows."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.telegram.workflows.message_handling_workflow import MessageHandlingWorkflow
+from app.telegram.workflows.member_management_workflow import MemberManagementWorkflow
+from app.telegram.workflows.scheduled_messaging_workflow import ScheduledMessagingWorkflow
+from app.telegram.workflows.media_processing_workflow import MediaProcessingWorkflow
+from app.telegram.workflows.auto_like_feedback_workflow import AutoLikeFeedbackWorkflow
+from app.telegram.workflows.adaptive_frequency_workflow import AdaptiveFrequencyWorkflow
+from app.telegram.workflows.message_stitching_workflow import MessageStitchingWorkflow
+
+
+@pytest.mark.parametrize(
+    "workflow_cls",
+    [
+        MessageHandlingWorkflow,
+        MemberManagementWorkflow,
+        ScheduledMessagingWorkflow,
+        MediaProcessingWorkflow,
+        AutoLikeFeedbackWorkflow,
+        AdaptiveFrequencyWorkflow,
+        MessageStitchingWorkflow,
+    ],
+)
+def test_telegram_workflows_expose_metadata(workflow_cls):
+    """Ensure each Telegram workflow advertises metadata fields."""
+
+    bot = MagicMock()
+    workflow = workflow_cls(bot)
+
+    assert isinstance(workflow.title, str) and workflow.title.strip()
+    assert isinstance(workflow.description, str) and workflow.description.strip()
+    assert isinstance(workflow.goal, str) and workflow.goal.strip()
+
+    assert isinstance(workflow.kpis, list) and workflow.kpis
+    for kpi in workflow.kpis:
+        assert {"name", "target", "description"}.issubset(kpi.keys())
+        assert all(isinstance(kpi[key], str) and kpi[key].strip() for key in ("name", "target", "description"))

--- a/app/telegram/workflows/workflow_suite.py
+++ b/app/telegram/workflows/workflow_suite.py
@@ -60,7 +60,8 @@ class WorkflowSuite:
         return {
             'enabled_workflows': self.enabled_workflows,
             'running': self.running,
-            'workflow_stats': self.integration.get_workflow_stats()
+            'workflow_stats': self.integration.get_workflow_stats(),
+            'workflow_metadata': self.integration.get_workflow_metadata(),
         }
 
     def add_workflow(self, workflow_name: str) -> bool:


### PR DESCRIPTION
## Summary
- add title, description, goal, and KPI metadata to Telegram workflows and expose it through the workflow suite
- extend Discord workflow definitions with explicit titles and descriptions and surface the metadata via the suite API
- add unit tests that ensure all Telegram and Discord workflows provide the required metadata fields

## Testing
- PYTHONPATH=app/discord pytest app/telegram/workflows/tests/test_workflow_metadata.py app/discord/workflows/tests/test_discord_workflows.py::test_discord_workflows_include_metadata


------
https://chatgpt.com/codex/tasks/task_e_68e3ef8d5ec88329a144a1eb98405e2d