### PR TITLE
Refine dashboard layout with tabbed assistant views

### DIFF
--- a/nice-gui/app/components/activity.py
+++ b/nice-gui/app/components/activity.py
@@ -12,12 +12,12 @@ from ..state import DashboardState
 def render_activity_log(state: DashboardState) -> None:
     """Render the latest activity feed."""
 
-    with ui.card().classes("w-full max-w-md"):
+    with ui.card().classes("w-full border border-gray-200 shadow-sm"):
         ui.label("Recent Activity").classes("text-lg font-semibold")
         ui.label("Latest configuration changes across the workspace.").classes(
             "text-sm text-gray-600"
         )
-        container = ui.column().classes("gap-1 mt-2")
+        container = ui.column().classes("gap-2 mt-3")
 
     def update(entries: List[str]) -> None:
         container.clear()
@@ -27,6 +27,8 @@ def render_activity_log(state: DashboardState) -> None:
             return
         for entry in entries:
             with container:
-                ui.label(entry).classes("text-sm")
+                ui.label(entry).classes(
+                    "text-sm bg-gray-50 border border-gray-100 rounded-md px-3 py-2"
+                )
 
     state.subscribe_activity(update)

--- a/nice-gui/app/components/assistants.py
+++ b/nice-gui/app/components/assistants.py
@@ -1,0 +1,77 @@
+"""AI assistant overview cards."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict
+
+from nicegui import ui
+
+from ..controllers import BotController
+from ..state import DashboardState
+
+_BADGE_BASE = "rounded-full px-2 py-1 text-xs font-medium"
+
+
+@dataclass
+class AssistantOverview:
+    """Hold references to update assistant status badges."""
+
+    badges: Dict[str, ui.label]
+    controller: BotController
+
+    def apply_status(self, bot_name: str, active: bool) -> None:
+        """Update badge text and tone for ``bot_name``."""
+
+        badge = self.badges[bot_name]
+        badge.set_text("Active" if active else "Paused")
+        tone = "bg-green-100 text-green-700" if active else "bg-orange-100 text-orange-700"
+        badge.classes(replace=f"{_BADGE_BASE} {tone}")
+
+
+def render_ai_assistants(state: DashboardState) -> AssistantOverview:
+    """Render AI assistant capabilities and live status."""
+
+    controller = state.bot_controller
+    badges: Dict[str, ui.label] = {}
+
+    with ui.card().classes("w-full border border-gray-200 shadow-sm"):
+        with ui.column().classes("gap-3"):
+            ui.label("AI Assistants").classes("text-lg font-semibold")
+            ui.label(
+                "Monitor active assistants, their specialties, and supported workflows."
+            ).classes("text-sm text-gray-600")
+
+            for bot in state.bots:
+                with ui.column().classes(
+                    "gap-2 w-full bg-gray-50 border border-gray-100 rounded-lg px-3 py-3"
+                ):
+                    with ui.row().classes("items-center justify-between"):
+                        ui.label(bot.bot_name).classes("text-sm font-medium")
+                        badge = ui.label("").classes(_BADGE_BASE)
+                        badges[bot.bot_name] = badge
+
+                    ui.label(f"Model · {bot.bot_model}").classes(
+                        "text-xs text-gray-500"
+                    )
+                    ui.label(
+                        "Focus · " + bot.function.replace("_", " ").title()
+                    ).classes("text-xs text-gray-500")
+
+                    if bot.capabilities:
+                        with ui.row().classes("flex-wrap gap-2"):
+                            for capability in sorted(bot.capabilities):
+                                ui.chip(capability.replace("_", " ").title()).classes(
+                                    "bg-white border border-gray-200 text-xs"
+                                )
+
+    view = AssistantOverview(badges=badges, controller=controller)
+
+    for bot in state.bots:
+        view.apply_status(bot.bot_name, controller.get_status(bot.bot_name))
+        controller.subscribe_status(
+            bot.bot_name,
+            lambda active, name=bot.bot_name: view.apply_status(name, active),
+        )
+
+    return view

--- a/nice-gui/app/components/auth.py
+++ b/nice-gui/app/components/auth.py
@@ -10,7 +10,7 @@ from ..state import DashboardState
 def render_authentication(state: DashboardState) -> None:
     """Render login, logout, and SaaS token controls."""
 
-    with ui.card().classes("w-full max-w-xl"):
+    with ui.card().classes("w-full border border-gray-200 shadow-sm"):
         ui.label("Authentication").classes("text-lg font-semibold")
         status_label = ui.label("").classes("text-sm text-gray-600")
 
@@ -19,11 +19,14 @@ def render_authentication(state: DashboardState) -> None:
 
         state.subscribe_auth(update_status)
 
-        ui.button("Log out", on_click=state.logout).props("color=warning").classes(
-            "mt-2 self-start"
-        )
+        with ui.row().classes("gap-2 mt-2"):
+            ui.button("Switch Account", on_click=state.logout).props(
+                "color=warning"
+            )
 
-        with ui.expansion("Dice Email Login", value=True).classes("mt-2"):
+        with ui.expansion("Dice Email Login", value=True).classes(
+            "mt-2 rounded-lg border border-gray-100"
+        ):
             email_input = ui.input("Dice Email", placeholder="you@example.com").classes(
                 "w-full"
             )
@@ -45,7 +48,9 @@ def render_authentication(state: DashboardState) -> None:
 
             ui.button("Sign in", on_click=handle_login).classes("mt-2")
 
-        with ui.expansion("SaaS Provider Login").classes("mt-2"):
+        with ui.expansion("SaaS Provider Login").classes(
+            "mt-2 rounded-lg border border-gray-100"
+        ):
             token_input = ui.input("Paste token").classes("w-full")
             link_label = ui.label("").classes("text-xs text-gray-500")
 

--- a/nice-gui/app/components/bots.py
+++ b/nice-gui/app/components/bots.py
@@ -40,32 +40,43 @@ def render_bot_management(
     controller: BotController = state.bot_controller
     toggles: Dict[str, ui.switch] = {}
 
-    with ui.card().classes("w-full max-w-xl"):
-        ui.label("Bot Management").classes("text-lg font-semibold")
-        helper_label = ui.label("").classes("text-sm text-gray-600")
+    with ui.card().classes("w-full border border-gray-200 shadow-sm"):
+        with ui.column().classes("gap-3"):
+            ui.label("Automation Controls").classes("text-lg font-semibold")
+            helper_label = ui.label("").classes("text-sm text-gray-600")
 
-        for bot in state.bots:
-            status_label = ui.label(
-                f"{bot.bot_name} automation status: {'Active' if controller.get_status(bot.bot_name) else 'Paused'}"
-            ).classes("text-sm")
-            toggle = ui.switch(
-                f"Toggle {bot.bot_name} automation",
-                value=controller.get_status(bot.bot_name),
-            )
+            for bot in state.bots:
+                active = controller.get_status(bot.bot_name)
+                with ui.row().classes(
+                    "items-center justify-between gap-4 w-full bg-gray-50 border border-gray-100 rounded-lg px-3 py-2"
+                ):
+                    with ui.column().classes("gap-1"):
+                        ui.label(bot.bot_name).classes("text-sm font-medium")
+                        status_label = ui.label("").classes(
+                            "text-xs text-gray-500"
+                        )
+                        status_label.set_text(
+                            f"Automation status: {'Active' if active else 'Paused'}"
+                        )
+                    toggle = ui.switch(
+                        "", value=active
+                    ).props("dense")
 
-            def handle_change(event, name=bot.bot_name) -> None:
-                state.toggle_bot(name, bool(event.value))
+                def handle_change(event, name=bot.bot_name) -> None:
+                    state.toggle_bot(name, bool(event.value))
 
-            toggle.on_value_change(handle_change)
-            toggles[bot.bot_name] = toggle
+                toggle.on_value_change(handle_change)
+                toggles[bot.bot_name] = toggle
 
-            def handle_status_update(active: bool, name=bot.bot_name, label=status_label) -> None:
-                label.set_text(
-                    f"{name} automation status: {'Active' if active else 'Paused'}"
-                )
-                on_status_change()
+                def handle_status_update(
+                    active: bool, name=bot.bot_name, label=status_label
+                ) -> None:
+                    label.set_text(
+                        f"Automation status: {'Active' if active else 'Paused'}"
+                    )
+                    on_status_change()
 
-            controller.subscribe_status(bot.bot_name, handle_status_update)
+                controller.subscribe_status(bot.bot_name, handle_status_update)
 
     view = BotManagementView(toggles=toggles, helper_label=helper_label)
     view.apply_role(state.role)

--- a/nice-gui/app/components/credits.py
+++ b/nice-gui/app/components/credits.py
@@ -12,16 +12,17 @@ def render_credit_summary(state: DashboardState) -> None:
 
     plan = state.plan
     subscription = state.subscription
-    with ui.card().classes("w-full max-w-md"):
+    with ui.card().classes("w-full border border-gray-200 shadow-sm"):
         ui.label("Credits & Billing").classes("text-lg font-semibold")
         ui.label(f"Plan: {plan.name} ({plan.tier.value})").classes("text-sm")
         ui.label(
             f"Renewal date: {subscription.current_period_end.date().isoformat()}"
         ).classes("text-sm text-gray-600")
         usage_label = ui.label(state.credit_summary()).classes("text-sm text-gray-600")
+        ui.separator().classes("my-2")
         ui.label(
             "Feature highlights: analytics, SSO, advanced moderation"
-        ).classes("text-xs text-gray-500 mt-2")
+        ).classes("text-xs text-gray-500")
 
         ui.label("Purchase add-on credits").classes("text-sm font-medium mt-4")
         selected = {"amount": 25}

--- a/nice-gui/app/components/profile.py
+++ b/nice-gui/app/components/profile.py
@@ -11,17 +11,28 @@ def render_profile_card(state: DashboardState) -> None:
     """Render profile details sourced from the tenant user model."""
 
     user = state.user
-    with ui.card().classes("w-full max-w-md"):
-        ui.label("Profile Management").classes("text-lg font-semibold")
-        ui.label(
-            f"{user.nickname} ({user.email})" if user.email else user.nickname
-        ).classes("text-sm")
-        ui.label(f"Timezone: {user.timezone}").classes("text-sm text-gray-600")
-        ui.label(
-            f"Preferred contact: {user.preferred_contact_method.value.replace('_', ' ').title()}"
-        ).classes("text-sm text-gray-600")
-        ui.label(
-            "Two-factor authentication is enabled"
-            if user.two_factor_enabled
-            else "Two-factor authentication is disabled"
-        ).classes("text-sm text-gray-600")
+    with ui.card().classes("w-full border border-gray-200 shadow-sm"):
+        with ui.column().classes("gap-3"):
+            ui.label("Profile Overview").classes("text-lg font-semibold")
+            with ui.row().classes("items-center gap-3"):
+                initials = (user.nickname or "?")[:2].upper()
+                ui.avatar(initials).classes("bg-primary-100 text-primary-600")
+                with ui.column().classes("gap-1"):
+                    ui.label(user.nickname).classes("text-base font-medium")
+                    if user.email:
+                        ui.label(user.email).classes("text-sm text-gray-500")
+            with ui.row().classes("gap-4 flex-wrap"):
+                ui.chip(f"Timezone · {user.timezone}").classes(
+                    "bg-gray-100 text-gray-700 text-xs"
+                )
+                ui.chip(
+                    "Contact · "
+                    + user.preferred_contact_method.value.replace("_", " ").title()
+                ).classes("bg-gray-100 text-gray-700 text-xs")
+                ui.chip(
+                    "2FA · Enabled" if user.two_factor_enabled else "2FA · Disabled"
+                ).classes(
+                    "bg-green-100 text-green-700 text-xs"
+                    if user.two_factor_enabled
+                    else "bg-orange-100 text-orange-700 text-xs"
+                )

--- a/nice-gui/app/components/settings.py
+++ b/nice-gui/app/components/settings.py
@@ -14,19 +14,27 @@ from ..state import DashboardState
 def render_settings_panel(state: DashboardState) -> None:
     """Render switches for notification preferences and security settings."""
 
-    with ui.card().classes("w-full max-w-md"):
-        ui.label("Settings").classes("text-lg font-semibold")
-        ui.label(
-            "Tune notification channels and security without leaving the dashboard."
-        ).classes("text-sm text-gray-600")
+    with ui.card().classes("w-full border border-gray-200 shadow-sm"):
+        with ui.column().classes("gap-4"):
+            ui.label("Settings Center").classes("text-lg font-semibold")
+            ui.label(
+                "Personalize how updates and security prompts reach your team."
+            ).classes("text-sm text-gray-600")
 
-        _render_notification_switches(state)
-        _render_security_controls(state)
+            with ui.expansion("Notification Preferences", value=True).classes(
+                "rounded-lg border border-gray-100"
+            ):
+                _render_notification_switches(state)
+
+            with ui.expansion("Security Controls", value=True).classes(
+                "rounded-lg border border-gray-100"
+            ):
+                _render_security_controls(state)
 
 
 def _render_notification_switches(state: DashboardState) -> None:
     preferences = state.user.notification_preferences
-    ui.label("Notifications").classes("text-sm font-medium mt-3")
+    ui.label("Channels").classes("text-sm font-medium")
     for notification in _sorted_notifications(preferences.keys()):
         switch = ui.switch(
             state.notification_label(notification),
@@ -40,7 +48,7 @@ def _render_notification_switches(state: DashboardState) -> None:
 
 
 def _render_security_controls(state: DashboardState) -> None:
-    ui.label("Security").classes("text-sm font-medium mt-4")
+    ui.label("Authentication").classes("text-sm font-medium")
     two_factor_switch = ui.switch(
         "Two-factor authentication", value=state.user.two_factor_enabled
     )

--- a/nice-gui/app/pages/dashboard.py
+++ b/nice-gui/app/pages/dashboard.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 from nicegui import ui
 
 from ..components.activity import render_activity_log
+from ..components.assistants import render_ai_assistants
 from ..components.auth import render_authentication
-from ..components.bots import render_bot_management
+from ..components.bots import BotManagementView, render_bot_management
 from ..components.credits import render_credit_summary
 from ..components.profile import render_profile_card
 from ..components.settings import render_settings_panel
@@ -19,42 +20,83 @@ def render_dashboard() -> None:
     state = DashboardState.demo()
     ui.page_title("Operations Control Center")
 
-    with ui.column().classes("gap-4 w-full"):
-        ui.label("Operations Control Center").classes("text-2xl font-semibold")
-        ui.label(
-            "Coordinate profiles, settings, automations, and credits in one view."
-        ).classes("text-sm text-gray-500")
+    with ui.column().classes("w-full max-w-6xl mx-auto gap-6 pb-10"):
+        with ui.card().classes(
+            "w-full border border-gray-200 shadow-sm bg-white/80 backdrop-blur"
+        ):
+            with ui.column().classes("gap-3"):
+                ui.label("Operations Control Center").classes(
+                    "text-2xl font-semibold"
+                )
+                ui.label(
+                    "Coordinate profiles, automation, and credits in a single workspace."
+                ).classes("text-sm text-gray-500")
 
-        role_label = ui.label(f"Current role: {state.role}").classes(
-            "text-sm text-gray-600"
-        )
-        summary_label = ui.label(state.bot_summary()).classes(
-            "text-sm text-gray-600"
-        )
+                with ui.row().classes(
+                    "items-center justify-between gap-3 flex-wrap"
+                ):
+                    role_label = ui.label(f"Current role: {state.role}").classes(
+                        "text-sm text-gray-600"
+                    )
+                    summary_label = ui.label(state.bot_summary()).classes(
+                        "text-sm text-gray-600"
+                    )
 
-        def refresh_summary() -> None:
-            summary_label.set_text(state.bot_summary())
+                def refresh_summary() -> None:
+                    summary_label.set_text(state.bot_summary())
 
-        with ui.row().classes("gap-2"):
-            ui.button("View as User", on_click=lambda: state.set_role(Role.USER)).props(
-                "color=primary"
-            )
-            ui.button("View as Admin", on_click=lambda: state.set_role(Role.ADMIN)).props(
-                "color=accent"
-            )
+                with ui.row().classes("gap-2 flex-wrap"):
+                    ui.button(
+                        "View as User", on_click=lambda: state.set_role(Role.USER)
+                    ).props("color=primary")
+                    ui.button(
+                        "View as Admin", on_click=lambda: state.set_role(Role.ADMIN)
+                    ).props("color=accent")
 
-        with ui.row().classes("items-start gap-4 flex-wrap"):
-            with ui.column().classes("gap-4"):
-                bot_view = render_bot_management(state, refresh_summary)
-                render_activity_log(state)
-            with ui.column().classes("gap-4"):
-                render_authentication(state)
-                render_profile_card(state)
-                render_settings_panel(state)
+        bot_view_holder: dict[str, BotManagementView | None] = {"view": None}
+
+        with ui.row().classes("w-full gap-6 flex-col xl:flex-row"):
+            with ui.column().classes("flex-1 gap-4 w-full"):
+                tabs = ui.tabs(
+                    {
+                        "profile": "Profile",
+                        "settings": "Settings",
+                        "bots": "Bots",
+                        "assistants": "AI Assistants",
+                    },
+                    value="profile",
+                ).classes("w-full bg-white/80 border border-gray-200 rounded-lg")
+
+                with ui.tab_panels(tabs, value="profile").classes(
+                    "w-full bg-white/90 border border-gray-200 rounded-lg"
+                ):
+                    with ui.tab_panel("profile"):
+                        with ui.column().classes("gap-4 p-4"):
+                            render_profile_card(state)
+                            render_authentication(state)
+
+                    with ui.tab_panel("settings"):
+                        with ui.column().classes("gap-4 p-4"):
+                            render_settings_panel(state)
+
+                    with ui.tab_panel("bots"):
+                        with ui.column().classes("gap-4 p-4"):
+                            bot_view_holder["view"] = render_bot_management(
+                                state, refresh_summary
+                            )
+
+                    with ui.tab_panel("assistants"):
+                        with ui.column().classes("gap-4 p-4"):
+                            render_ai_assistants(state)
+
+            with ui.column().classes("w-full xl:max-w-sm gap-4"):
                 render_credit_summary(state)
+                render_activity_log(state)
 
     def handle_role_change(role: str) -> None:
         role_label.set_text(f"Current role: {role}")
-        bot_view.apply_role(role)
+        view = bot_view_holder["view"]
+        if view is not None:
+            view.apply_role(role)
 
     state.subscribe_role(handle_role_change)


### PR DESCRIPTION
## Summary
- reorganized the dashboard hero into a focused control header with role toggles and responsive layout
- introduced tabbed navigation for profile, settings, bots, and AI assistant sections with refreshed card styling
- added an AI assistant overview component and modernized authentication, settings, activity, and billing cards

## Testing
- pytest -q *(fails: missing optional dependencies such as fastapi and workers modules)*

------
https://chatgpt.com/codex/tasks/task_e_68e3f8392e248329920642122587d856