### PR TITLE
Organize dashboard tabs for profile, settings, and connections

### DIFF
--- a/nice-gui/app/components/assistants.py
+++ b/nice-gui/app/components/assistants.py
@@ -1,0 +1,67 @@
+"""AI assistant overview cards."""
+
+from __future__ import annotations
+
+from nicegui import ui
+
+from ..state import DashboardState
+
+
+def render_ai_assistants(state: DashboardState) -> None:
+    """Render a grid of AI assistants with their capabilities."""
+
+    controller = state.bot_controller
+    with ui.card().classes("w-full max-w-4xl"):
+        ui.label("AI Assistant Overview").classes("text-lg font-semibold")
+        ui.label(
+            "Monitor each assistant's model, focus area, and readiness in one glance."
+        ).classes("text-sm text-gray-600")
+
+        with ui.element("div").classes(
+            "grid gap-3 mt-4 grid-cols-1 md:grid-cols-2"
+        ):
+            for bot in state.bots:
+                active = controller.get_status(bot.bot_name)
+                status_label = "Active" if active else "Paused"
+                status_color = "positive" if active else "grey"
+                with ui.card().classes(
+                    "shadow-none border border-gray-200 dark:border-gray-700 "
+                    "rounded-xl bg-white dark:bg-gray-900"
+                ):
+                    with ui.column().classes("gap-2"):
+                        with ui.row().classes(
+                            "items-center justify-between gap-2"
+                        ):
+                            ui.label(bot.bot_name).classes("text-base font-semibold")
+                            ui.badge(status_label).props(f"color={status_color}")
+
+                        ui.label(f"Model: {bot.bot_model}").classes(
+                            "text-sm text-gray-600"
+                        )
+                        ui.label(
+                            f"Focus: {bot.function.replace('_', ' ').title()}"
+                        ).classes("text-sm text-gray-600")
+
+                        if bot.capabilities:
+                            ui.label("Capabilities").classes(
+                                "text-xs font-semibold text-gray-500 uppercase"
+                            )
+                            with ui.row().classes("gap-2 flex-wrap"):
+                                for capability in bot.capabilities:
+                                    ui.chip(capability.replace("_", " ").title()).props(
+                                        "color=primary"
+                                    ).classes("text-xs")
+
+                        if bot.settings:
+                            ui.label("Key settings").classes(
+                                "text-xs font-semibold text-gray-500 uppercase"
+                            )
+                            with ui.column().classes("gap-1"):
+                                for key, value in bot.settings.items():
+                                    ui.label(f"{key.replace('_', ' ').title()}: {value}").classes(
+                                        "text-xs text-gray-600"
+                                    )
+
+                        ui.label(
+                            "Automation is ready for handoff when enabled."
+                        ).classes("text-xs text-gray-500 pt-2")

--- a/nice-gui/app/components/configuration.py
+++ b/nice-gui/app/components/configuration.py
@@ -1,0 +1,46 @@
+"""Reusable configuration section renderer."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+from nicegui import ui
+
+from ..models.configuration import ConfigurationSection
+
+
+def render_configuration_sections(
+    title: str,
+    subtitle: str,
+    sections: Sequence[ConfigurationSection],
+) -> None:
+    """Render grouped configuration values inside expandable sections."""
+
+    if not sections:
+        return
+
+    with ui.card().classes("w-full max-w-4xl"):
+        ui.label(title).classes("text-lg font-semibold")
+        if subtitle:
+            ui.label(subtitle).classes("text-sm text-gray-600")
+
+        for section in sections:
+            with ui.expansion(section.title, value=True).classes(
+                "mt-3 border border-gray-200 dark:border-gray-800 rounded-xl"
+            ):
+                if section.description:
+                    ui.label(section.description).classes(
+                        "text-xs text-gray-500 mb-2"
+                    )
+                for key, value in section.items:
+                    with ui.row().classes(
+                        "justify-between items-start gap-3 py-1 border-b "
+                        "border-gray-100 dark:border-gray-700 last:border-0"
+                    ):
+                        ui.label(key).classes(
+                            "font-mono text-xs text-gray-500 break-all"
+                        )
+                        ui.label(value or "Not configured").classes(
+                            "text-xs sm:text-sm text-gray-700 dark:text-gray-200 "
+                            "text-right break-all"
+                        )

--- a/nice-gui/app/data/configuration.py
+++ b/nice-gui/app/data/configuration.py
@@ -1,0 +1,186 @@
+"""Demo configuration data grouped for dashboard presentation."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+from ..models.configuration import ConfigurationSection
+
+
+def build_demo_configuration() -> tuple[
+    Sequence[ConfigurationSection],
+    Sequence[ConfigurationSection],
+    Sequence[ConfigurationSection],
+]:
+    """Return configuration sections grouped by profile, settings, and connections."""
+
+    profile_sections: Sequence[ConfigurationSection] = (
+        ConfigurationSection(
+            title="Notifications & Alerts",
+            description="Email relay details and escalation contacts for the workspace.",
+            items=(
+                ("SMTP_SERVER", "smtp.gmail.com"),
+                ("SMTP_PORT", "587"),
+                ("SMTP_USERNAME", "your-email@gmail.com"),
+                ("SMTP_PASSWORD", "your-app-password"),
+                ("ADMIN_NOTIFICATION_EMAILS", "admin@yourdomain.com"),
+            ),
+        ),
+        ConfigurationSection(
+            title="Notification Webhooks",
+            description="Outbound webhook destination for real-time alerts.",
+            items=(("NOTIFICATION_WEBHOOK_URL", ""),),
+        ),
+        ConfigurationSection(
+            title="AI Credentials",
+            description="Primary key used for AI-powered automation across the tenant.",
+            items=(("AI_API_KEY", "your_ai_api_key"),),
+        ),
+    )
+
+    settings_sections: Sequence[ConfigurationSection] = (
+        ConfigurationSection(
+            title="Database",
+            description="Connection target for persistent bot data and audit logs.",
+            items=(("DATABASE_URL", "sqlite+aiosqlite:///./groupme_bots.db"),),
+        ),
+        ConfigurationSection(
+            title="Platform Settings",
+            description="Automation defaults that govern platform-specific behaviour.",
+            items=(
+                ("GROUPME_AUTO_JOIN_GROUPS", "true"),
+                ("GROUPME_MESSAGE_COOLDOWN", "5"),
+                ("DISCORD_AUTO_JOIN_GUILDS", "true"),
+                ("DISCORD_COMMAND_PREFIX", "!"),
+                ("TELEGRAM_AUTO_JOIN_GROUPS", "true"),
+                ("TELEGRAM_MESSAGE_COOLDOWN", "3"),
+                ("SIGNAL_AUTO_REGISTER", "true"),
+                ("SIGNAL_MESSAGE_COOLDOWN", "2"),
+            ),
+        ),
+        ConfigurationSection(
+            title="Advanced Features",
+            description="Feature flags that tune AI, moderation, and content pipelines.",
+            items=(
+                ("AI_ENABLED", "false"),
+                ("AI_PROVIDER", "openai"),
+                ("AI_MODEL", "gpt-3.5-turbo"),
+                ("NLP_ENABLED", "false"),
+                ("NLP_LANGUAGE", "en"),
+                ("AUTO_MODERATION_ENABLED", "false"),
+                ("TOXICITY_THRESHOLD", "0.8"),
+                ("SPAM_DETECTION_ENABLED", "true"),
+                ("CONTENT_FILTER_ENABLED", "false"),
+                ("PROFANITY_FILTER", "true"),
+                ("LINK_PREVIEW_ENABLED", "true"),
+            ),
+        ),
+        ConfigurationSection(
+            title="Monitoring & Analytics",
+            description="Operational monitoring toggles and collection intervals.",
+            items=(
+                ("ANALYTICS_ENABLED", "false"),
+                ("ANALYTICS_TRACKING_ID", ""),
+                ("HEALTH_CHECK_ENABLED", "true"),
+                ("HEALTH_CHECK_PATH", "/health"),
+                ("METRICS_ENABLED", "false"),
+                ("METRICS_COLLECTION_INTERVAL", "60"),
+            ),
+        ),
+        ConfigurationSection(
+            title="Backup & Migration",
+            description="Disaster recovery configuration and migration readiness.",
+            items=(
+                ("BACKUP_ENABLED", "true"),
+                ("BACKUP_INTERVAL_HOURS", "24"),
+                ("BACKUP_RETENTION_DAYS", "7"),
+                ("BACKUP_DESTINATION", "./backups"),
+                ("MIGRATION_ENABLED", "false"),
+                ("MIGRATION_SOURCE_PLATFORM", ""),
+                ("MIGRATION_TARGET_PLATFORM", ""),
+            ),
+        ),
+    )
+
+    connection_sections: Sequence[ConfigurationSection] = (
+        ConfigurationSection(
+            title="Discord",
+            description="Tokens and OAuth configuration for Discord automations.",
+            items=(
+                ("DISCORD_BOT_TOKEN", "your_discord_bot_token_here"),
+                ("DISCORD_CLIENT_ID", "your_discord_client_id"),
+                ("DISCORD_CLIENT_SECRET", "your_discord_client_secret"),
+                ("DISCORD_MAIN_GUILD_ID", "your_main_discord_server_id"),
+                ("DISCORD_WEBHOOK_URL", "https://discord.com/api/webhooks/your-webhook-id/your-webhook-token"),
+            ),
+        ),
+        ConfigurationSection(
+            title="Telegram",
+            description="Bot credentials and webhook endpoints for Telegram.",
+            items=(
+                ("TELEGRAM_BOT_TOKEN", "your_telegram_bot_token_here"),
+                ("TELEGRAM_WEBHOOK_URL", "https://your-domain.com/api/v1/telegram/webhook"),
+                ("TELEGRAM_ADMIN_IDS", "123456789,987654321"),
+            ),
+        ),
+        ConfigurationSection(
+            title="Signal",
+            description="Signal numbers and optional API keys for messaging bridges.",
+            items=(
+                ("SIGNAL_PHONE_NUMBER_1", "+1234567890"),
+                ("SIGNAL_PHONE_NUMBER_2", "+1987654321"),
+                ("SIGNAL_API_KEY", "your_signal_api_key_if_needed"),
+            ),
+        ),
+        ConfigurationSection(
+            title="E-Commerce Integrations",
+            description="Commerce platform tokens for synchronized storefront workflows.",
+            items=(
+                ("SHOPIFY_ACCESS_TOKEN", "your_shopify_access_token"),
+                ("SHOPIFY_STORE_URL", "your-store.myshopify.com"),
+                ("WOOCOMMERCE_URL", "https://your-store.com"),
+                ("WOOCOMMERCE_CONSUMER_KEY", "your_woocommerce_consumer_key"),
+                ("WOOCOMMERCE_CONSUMER_SECRET", "your_woocommerce_consumer_secret"),
+            ),
+        ),
+        ConfigurationSection(
+            title="Payment Processing",
+            description="Payment gateway keys for billing automation across channels.",
+            items=(
+                ("STRIPE_PUBLIC_KEY", "pk_test_your_stripe_public_key"),
+                ("STRIPE_SECRET_KEY", "sk_test_your_stripe_secret_key"),
+                ("STRIPE_WEBHOOK_SECRET", "whsec_your_stripe_webhook_secret"),
+                ("PAYPAL_CLIENT_ID", "your_paypal_client_id"),
+                ("PAYPAL_CLIENT_SECRET", "your_paypal_client_secret"),
+                ("PAYPAL_MODE", "sandbox"),
+            ),
+        ),
+        ConfigurationSection(
+            title="AWS & External Services",
+            description="Cloud credentials and third-party service tokens used by bots.",
+            items=(
+                ("AWS_ACCESS_KEY_ID", "your_aws_access_key_id"),
+                ("AWS_SECRET_ACCESS_KEY", "your_aws_secret_access_key"),
+                ("AWS_REGION", "us-east-1"),
+                ("AWS_S3_BUCKET", "your-s3-bucket-name"),
+                ("AWS_SES_SOURCE_EMAIL", "noreply@yourdomain.com"),
+                ("REDDIT_CLIENT_ID", "your_reddit_client_id"),
+                ("REDDIT_CLIENT_SECRET", "your_reddit_client_secret"),
+                ("PUSHBULLET_API_KEY", "your_pushbullet_api_key"),
+                ("TWITTER_API_KEY", "your_twitter_api_key"),
+                ("TWITTER_API_SECRET", "your_twitter_api_secret"),
+                ("TWITTER_ACCESS_TOKEN", "your_twitter_access_token"),
+                ("TWITTER_ACCESS_SECRET", "your_twitter_access_token_secret"),
+            ),
+        ),
+        ConfigurationSection(
+            title="Webhooks & Integrations",
+            description="Generic integration endpoints for event forwarding.",
+            items=(
+                ("SLACK_WEBHOOK_URL", "https://hooks.slack.com/services/your-slack-webhook"),
+                ("GENERIC_WEBHOOK_URL", "https://your-service.com/webhook"),
+            ),
+        ),
+    )
+
+    return profile_sections, settings_sections, connection_sections

--- a/nice-gui/app/models/configuration.py
+++ b/nice-gui/app/models/configuration.py
@@ -1,0 +1,15 @@
+"""Configuration section models for dashboard metadata."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence, Tuple
+
+
+@dataclass(frozen=True)
+class ConfigurationSection:
+    """Structured configuration data displayed in the dashboard."""
+
+    title: str
+    items: Sequence[Tuple[str, str]]
+    description: str | None = None

--- a/nice-gui/app/pages/dashboard.py
+++ b/nice-gui/app/pages/dashboard.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 from nicegui import ui
 
 from ..components.activity import render_activity_log
+from ..components.assistants import render_ai_assistants
 from ..components.auth import render_authentication
 from ..components.bots import render_bot_management
 from ..components.credits import render_credit_summary
+from ..components.configuration import render_configuration_sections
 from ..components.profile import render_profile_card
 from ..components.settings import render_settings_panel
 from ..state import DashboardState, Role
@@ -19,39 +21,80 @@ def render_dashboard() -> None:
     state = DashboardState.demo()
     ui.page_title("Operations Control Center")
 
-    with ui.column().classes("gap-4 w-full"):
-        ui.label("Operations Control Center").classes("text-2xl font-semibold")
-        ui.label(
-            "Coordinate profiles, settings, automations, and credits in one view."
-        ).classes("text-sm text-gray-500")
+    with ui.column().classes("gap-6 w-full max-w-6xl mx-auto pb-8"):
+        with ui.column().classes("gap-1"):
+            ui.label("Operations Control Center").classes(
+                "text-2xl font-semibold tracking-tight"
+            )
+            ui.label(
+                "Coordinate profiles, automations, and AI operations from a streamlined workspace."
+            ).classes("text-sm text-gray-500 max-w-2xl")
 
-        role_label = ui.label(f"Current role: {state.role}").classes(
-            "text-sm text-gray-600"
-        )
-        summary_label = ui.label(state.bot_summary()).classes(
-            "text-sm text-gray-600"
-        )
+        with ui.row().classes("gap-2 flex-wrap items-center"):
+            role_label = ui.label(f"Current role: {state.role}").classes(
+                "text-sm font-medium text-primary"
+            )
+            summary_label = ui.label(state.bot_summary()).classes(
+                "text-sm font-medium text-accent"
+            )
 
         def refresh_summary() -> None:
             summary_label.set_text(state.bot_summary())
 
-        with ui.row().classes("gap-2"):
+        with ui.row().classes("gap-2 flex-wrap"):
             ui.button("View as User", on_click=lambda: state.set_role(Role.USER)).props(
-                "color=primary"
+                "color=primary flat"
             )
             ui.button("View as Admin", on_click=lambda: state.set_role(Role.ADMIN)).props(
                 "color=accent"
             )
 
-        with ui.row().classes("items-start gap-4 flex-wrap"):
-            with ui.column().classes("gap-4"):
-                bot_view = render_bot_management(state, refresh_summary)
-                render_activity_log(state)
-            with ui.column().classes("gap-4"):
-                render_authentication(state)
-                render_profile_card(state)
-                render_settings_panel(state)
-                render_credit_summary(state)
+        with ui.tabs().classes(
+            "w-full max-w-6xl overflow-x-auto rounded-xl"
+        ) as tabs:
+            bots_tab = ui.tab("Bots & Automations", icon="smart_toy")
+            profile_tab = ui.tab("User Profile", icon="person")
+            settings_tab = ui.tab("User Settings", icon="tune")
+            connections_tab = ui.tab("Connections", icon="hub")
+            ai_tab = ui.tab("AI Assistants & Billing", icon="auto_awesome")
+
+        with ui.tab_panels(tabs, value=bots_tab).classes("w-full max-w-6xl"):
+            with ui.tab_panel(bots_tab):
+                with ui.row().classes("items-start gap-4 flex-wrap mt-4"):
+                    bot_view = render_bot_management(state, refresh_summary)
+                    render_activity_log(state)
+
+            with ui.tab_panel(profile_tab):
+                with ui.row().classes("items-start gap-4 flex-wrap mt-4"):
+                    render_profile_card(state)
+                    render_authentication(state)
+                render_configuration_sections(
+                    "Profile Configuration",
+                    "Review escalation contacts and AI credentials.",
+                    state.profile_sections,
+                )
+
+            with ui.tab_panel(settings_tab):
+                with ui.column().classes("gap-4 mt-4"):
+                    render_settings_panel(state)
+                    render_configuration_sections(
+                        "Workspace Settings",
+                        "Platform defaults, feature flags, and operational toggles.",
+                        state.settings_sections,
+                    )
+
+            with ui.tab_panel(connections_tab):
+                with ui.column().classes("gap-4 mt-4"):
+                    render_configuration_sections(
+                        "Connections",
+                        "External services linked to the automation suite.",
+                        state.connection_sections,
+                    )
+
+            with ui.tab_panel(ai_tab):
+                with ui.column().classes("gap-4 mt-4"):
+                    render_ai_assistants(state)
+                    render_credit_summary(state)
 
     def handle_role_change(role: str) -> None:
         role_label.set_text(f"Current role: {role}")

--- a/nice-gui/app/state.py
+++ b/nice-gui/app/state.py
@@ -11,7 +11,9 @@ from _schema.schemas.subscriptions import Plan, Subscription
 from _schema.schemas.users import NotificationType, User
 
 from .controllers import BotController
+from .data.configuration import build_demo_configuration
 from .factories import demo_payload
+from .models.configuration import ConfigurationSection
 from .models.auth import AuthState
 from .services.authentication import AuthenticationController
 from .services.billing import CheckoutService
@@ -37,6 +39,9 @@ class DashboardState:
     activation_credit_cost: int = 40
     auth: AuthState = field(default_factory=AuthState)
     addon_credits: int = 0
+    profile_sections: Sequence[ConfigurationSection] = field(default_factory=tuple)
+    settings_sections: Sequence[ConfigurationSection] = field(default_factory=tuple)
+    connection_sections: Sequence[ConfigurationSection] = field(default_factory=tuple)
 
     def __post_init__(self) -> None:
         self.activity_log: Deque[str] = deque(maxlen=8)
@@ -76,6 +81,7 @@ class DashboardState:
         """Create demo data derived from repository schemas."""
 
         user, plan, subscription, bots, controller, auth = demo_payload()
+        profile_sections, settings_sections, connection_sections = build_demo_configuration()
         return cls(
             user=user,
             plan=plan,
@@ -83,6 +89,9 @@ class DashboardState:
             bots=bots,
             bot_controller=controller,
             auth=auth,
+            profile_sections=profile_sections,
+            settings_sections=settings_sections,
+            connection_sections=connection_sections,
         )
 
     # Observers ------------------------------------------------------------

--- a/nice-gui/nicegui/__init__.py
+++ b/nice-gui/nicegui/__init__.py
@@ -56,17 +56,69 @@ if _REAL_MODULE is not None:
 
 else:
 
-    class _DummyUI:
-        """Minimal placeholder for the NiceGUI ``ui`` module."""
+    class _DummyApp:
+        """Small subset of the NiceGUI ``app`` object used by the project."""
 
-        def __getattr__(self, name: str) -> "_DummyUI":
-            def _noop(*_args, **_kwargs):  # type: ignore[override]
+        def __init__(self) -> None:
+            self._startup_callbacks = []
+            self._shutdown_callbacks = []
+
+        def on_startup(self, func):  # type: ignore[override]
+            """Register a startup callback and return the original function."""
+
+            self._startup_callbacks.append(func)
+            return func
+
+        def on_shutdown(self, func):  # type: ignore[override]
+            """Register a shutdown callback and return the original function."""
+
+            self._shutdown_callbacks.append(func)
+            return func
+
+        def _emit_startup(self) -> None:
+            for callback in list(self._startup_callbacks):
+                callback()
+
+        def _emit_shutdown(self) -> None:
+            for callback in list(self._shutdown_callbacks):
+                callback()
+
+
+    class _DummyElement:
+        """Placeholder element that mimics the fluent NiceGUI API."""
+
+        def __call__(self, *_args, **_kwargs) -> "_DummyElement":
+            return self
+
+        def __getattr__(self, _name: str):  # type: ignore[override]
+            def _noop(*_args, **_kwargs):
                 return self
 
             return _noop
 
-        def __call__(self, *_args, **_kwargs) -> "_DummyUI":
+        # Context manager support -------------------------------------------------
+        def __enter__(self) -> "_DummyElement":
             return self
 
-    ui = _DummyUI()
-    __all__ = ["ui"]
+        def __exit__(self, *_exc) -> None:
+            return None
+
+
+    class _DummyUI(_DummyElement):
+        """Minimal placeholder for the NiceGUI ``ui`` module."""
+
+        def __init__(self, dummy_app: _DummyApp) -> None:
+            super().__init__()
+            self._app = dummy_app
+
+        def run(self, builder, *_, **__):  # type: ignore[override]
+            """Invoke ``builder`` immediately and trigger lifecycle hooks."""
+
+            builder()
+            self._app._emit_startup()
+
+
+    _DUMMY_APP = _DummyApp()
+    app = _DUMMY_APP
+    ui = _DummyUI(_DUMMY_APP)
+    __all__ = ["app", "ui"]

--- a/nice-gui/nicegui/__init__.py
+++ b/nice-gui/nicegui/__init__.py
@@ -56,69 +56,7 @@ if _REAL_MODULE is not None:
 
 else:
 
-    class _DummyApp:
-        """Small subset of the NiceGUI ``app`` object used by the project."""
+    from ._stub_runtime import app, ui  # noqa: WPS347
+    from ._stub_runtime import __all__ as __all_stub
 
-        def __init__(self) -> None:
-            self._startup_callbacks = []
-            self._shutdown_callbacks = []
-
-        def on_startup(self, func):  # type: ignore[override]
-            """Register a startup callback and return the original function."""
-
-            self._startup_callbacks.append(func)
-            return func
-
-        def on_shutdown(self, func):  # type: ignore[override]
-            """Register a shutdown callback and return the original function."""
-
-            self._shutdown_callbacks.append(func)
-            return func
-
-        def _emit_startup(self) -> None:
-            for callback in list(self._startup_callbacks):
-                callback()
-
-        def _emit_shutdown(self) -> None:
-            for callback in list(self._shutdown_callbacks):
-                callback()
-
-
-    class _DummyElement:
-        """Placeholder element that mimics the fluent NiceGUI API."""
-
-        def __call__(self, *_args, **_kwargs) -> "_DummyElement":
-            return self
-
-        def __getattr__(self, _name: str):  # type: ignore[override]
-            def _noop(*_args, **_kwargs):
-                return self
-
-            return _noop
-
-        # Context manager support -------------------------------------------------
-        def __enter__(self) -> "_DummyElement":
-            return self
-
-        def __exit__(self, *_exc) -> None:
-            return None
-
-
-    class _DummyUI(_DummyElement):
-        """Minimal placeholder for the NiceGUI ``ui`` module."""
-
-        def __init__(self, dummy_app: _DummyApp) -> None:
-            super().__init__()
-            self._app = dummy_app
-
-        def run(self, builder, *_, **__):  # type: ignore[override]
-            """Invoke ``builder`` immediately and trigger lifecycle hooks."""
-
-            builder()
-            self._app._emit_startup()
-
-
-    _DUMMY_APP = _DummyApp()
-    app = _DUMMY_APP
-    ui = _DummyUI(_DUMMY_APP)
-    __all__ = ["app", "ui"]
+    __all__ = __all_stub

--- a/nice-gui/nicegui/_stub_runtime.py
+++ b/nice-gui/nicegui/_stub_runtime.py
@@ -1,0 +1,113 @@
+"""Lightweight runtime that emulates NiceGUI when the dependency is missing."""
+
+from __future__ import annotations
+
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import List
+
+from ._stub_template import render_static_dashboard
+
+
+class _DummyApp:
+    """Subset of the NiceGUI ``app`` hooks used by the dashboard."""
+
+    def __init__(self) -> None:
+        self._startup_callbacks: List = []
+        self._shutdown_callbacks: List = []
+
+    def on_startup(self, func):  # type: ignore[override]
+        self._startup_callbacks.append(func)
+        return func
+
+    def on_shutdown(self, func):  # type: ignore[override]
+        self._shutdown_callbacks.append(func)
+        return func
+
+    def _emit_startup(self) -> None:
+        for callback in list(self._startup_callbacks):
+            callback()
+
+    def _emit_shutdown(self) -> None:
+        for callback in list(self._shutdown_callbacks):
+            callback()
+
+
+class _DummyElement:
+    """Fluent placeholder for NiceGUI elements."""
+
+    def __call__(self, *_args, **_kwargs):  # type: ignore[override]
+        return self
+
+    def __getattr__(self, _name):  # type: ignore[override]
+        def _noop(*_args, **_kwargs):
+            return self
+
+        return _noop
+
+    def __enter__(self):  # type: ignore[override]
+        return self
+
+    def __exit__(self, *_exc):  # type: ignore[override]
+        return None
+
+
+class _DashboardHandler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+    html: str = ""
+
+    def do_GET(self):  # type: ignore[override]
+        if self.path not in {"/", "/index.html"}:
+            self.send_error(404)
+            return
+        content = self.html.encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.send_header("Content-Length", str(len(content)))
+        self.end_headers()
+        self.wfile.write(content)
+
+    def do_HEAD(self):  # type: ignore[override]
+        if self.path not in {"/", "/index.html"}:
+            self.send_error(404)
+            return
+        content_length = len(self.html.encode("utf-8"))
+        self.send_response(200)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.send_header("Content-Length", str(content_length))
+        self.end_headers()
+
+    def log_message(self, *_args, **_kwargs):  # type: ignore[override]
+        return
+
+
+class _DummyUI(_DummyElement):
+    """Minimal ``ui`` module exposing ``run``."""
+
+    def __init__(self, dummy_app: _DummyApp) -> None:
+        super().__init__()
+        self._app = dummy_app
+
+    def run(self, builder, *_, host: str = "127.0.0.1", port: int = 8080, **__):  # type: ignore[override]
+        builder()
+        self._app._emit_startup()
+
+        _DashboardHandler.html = render_static_dashboard()
+        server = ThreadingHTTPServer((host, port), _DashboardHandler)
+        print(
+            f"Stub NiceGUI server is rendering the dashboard at http://{host}:{port}",
+            flush=True,
+        )
+
+        try:
+            server.serve_forever()
+        except KeyboardInterrupt:  # pragma: no cover - manual termination
+            pass
+        finally:
+            server.server_close()
+            self._app._emit_shutdown()
+
+
+_DUMMY_APP = _DummyApp()
+app = _DUMMY_APP
+ui = _DummyUI(_DUMMY_APP)
+__all__ = ["app", "ui"]

--- a/nice-gui/nicegui/_stub_template.py
+++ b/nice-gui/nicegui/_stub_template.py
@@ -1,0 +1,227 @@
+"""HTML rendering helpers for the NiceGUI stub server."""
+
+from __future__ import annotations
+
+from typing import Any, Iterable, Iterator, List, Sequence, Tuple
+
+import textwrap
+
+
+def _tabbed_html(title: str, tabs: Iterable[str], active: str) -> str:
+    buttons = "".join(
+        f'<button class="tab-button{ " active" if name == active else "" }" '
+        f'data-tab="{name}">{name}</button>'
+        for name in tabs
+    )
+    return textwrap.dedent(
+        f"""
+        <header class="header">
+          <h1>{title}</h1>
+          <div class="tab-bar">{buttons}</div>
+        </header>
+        """
+    )
+
+
+def _definition_list(items: Iterable[Tuple[str, Any]]) -> str:
+    def render(value: Any) -> str:
+        if value in (None, ""):
+            return "Not configured"
+        return str(value)
+
+    return "".join(f"<dt>{key}</dt><dd>{render(value)}</dd>" for key, value in items)
+
+
+def _section_cards(sections: Sequence) -> str:
+    cards: List[str] = []
+    for section in sections:
+        description = (
+            f"<p class=\"muted\">{section.description}</p>"
+            if getattr(section, "description", None)
+            else ""
+        )
+        cards.append(
+            textwrap.dedent(
+                f"""
+                <article class="card">
+                  <h3>{section.title}</h3>
+                  {description}
+                  <dl>{_definition_list(section.items)}</dl>
+                </article>
+                """
+            )
+        )
+    return "".join(cards)
+
+
+def render_static_dashboard() -> str:
+    """Return a static HTML representation of the dashboard."""
+
+    from app.state import DashboardState
+
+    state = DashboardState.demo()
+    role_helper = (
+        "Bot controls are unlocked for administrators."
+        if state.role == "Admin"
+        else "Bot controls are locked while in user mode."
+    )
+    bots = "".join(
+        f"<li><strong>{bot.bot_name}</strong>: "
+        f"{'Active' if state.bot_controller.get_status(bot.bot_name) else 'Paused'}</li>"
+        for bot in state.bots
+    )
+    automation_card = (
+        f"<section class=\"card\"><h2>Bot Management</h2>"
+        f"<p class=\"muted\">{role_helper}</p><ul class=\"list\">{bots}</ul></section>"
+    )
+    activity = "".join(f"<li>{entry}</li>" for entry in state.activity_log)
+    activity_card = (
+        "<section class=\"card\"><h2>Recent Activity</h2>"
+        f"<ul class=\"list\">{activity}</ul></section>"
+    )
+    profile = textwrap.dedent(
+        f"""
+        <section class="card">
+          <h2>Profile Management</h2>
+          <p>{state.user.nickname} ({state.user.email})</p>
+          <p>Timezone: {state.user.timezone}</p>
+          <p>Preferred contact: {state.user.preferred_contact_method.value.replace('_', ' ').title()}</p>
+        </section>
+        """
+    )
+    auth_states = [state.auth.status_text()]
+    auth_states.append(
+        "Two-factor authentication is enabled"
+        if state.user.two_factor_enabled
+        else "Two-factor authentication is disabled"
+    )
+    auth = textwrap.dedent(
+        f"""
+        <section class="card">
+          <h2>Authentication</h2>
+          <ul class="list">{''.join(f'<li>{line}</li>' for line in auth_states)}</ul>
+        </section>
+        """
+    )
+    assistants: List[str] = []
+    for bot in state.bots:
+        capabilities = ", ".join(cap.replace("_", " ").title() for cap in bot.capabilities)
+        assistants.append(
+            textwrap.dedent(
+                f"""
+                <article class="card">
+                  <h3>{bot.bot_name} ({bot.bot_model})</h3>
+                  <p class="muted">Focus: {bot.function.replace('_', ' ').title()}</p>
+                  <p>Capabilities: {capabilities}</p>
+                  <dl>{_definition_list(bot.settings.items())}</dl>
+                </article>
+                """
+            )
+        )
+    assistants_grid = "".join(assistants)
+    billing = textwrap.dedent(
+        f"""
+        <section class="card">
+          <h2>Credits &amp; Billing</h2>
+          <p>{state.credit_summary()}</p>
+          <p class="muted">Selected package: 25 credits</p>
+        </section>
+        """
+    )
+
+    tabs = [
+        ("Bots & Automations", automation_card + activity_card),
+        ("User Profile", profile + auth + _section_cards(state.profile_sections)),
+        ("User Settings", textwrap.dedent(
+            f"""
+            <section class="card">
+              <h2>Settings</h2>
+              <p class="muted">Workspace notifications and preferences.</p>
+              {_section_cards(state.settings_sections)}
+            </section>
+            """
+        )),
+        ("Connections", textwrap.dedent(
+            f"""
+            <section class="card">
+              <h2>Connections</h2>
+              {_section_cards(state.connection_sections)}
+            </section>
+            """
+        )),
+        ("AI Assistants & Billing", assistants_grid + billing),
+    ]
+
+    def tab_names() -> Iterator[str]:
+        for name, _ in tabs:
+            yield name
+
+    content = "".join(
+        textwrap.dedent(
+            f"""
+            <section class="tab-content{' active' if index == 0 else ''}" data-tab="{name}">
+              {panel}
+            </section>
+            """
+        )
+        for index, (name, panel) in enumerate(tabs)
+    )
+
+    return textwrap.dedent(
+        f"""
+        <!DOCTYPE html>
+        <html lang="en">
+          <head>
+            <meta charset="utf-8" />
+            <title>Operations Control Center (Stub)</title>
+            <style>
+              body {{ font-family: 'Inter', system-ui, sans-serif; margin: 0; background: #f5f5f7; color: #111827; }}
+              .container {{ max-width: 1100px; margin: 0 auto; padding: 2rem 1.5rem 4rem; }}
+              .header h1 {{ margin: 0 0 0.5rem; font-size: 2rem; }}
+              .muted {{ color: #6b7280; }}
+              .tab-bar {{ display: flex; gap: 0.75rem; flex-wrap: wrap; margin-bottom: 1.5rem; }}
+              .tab-button {{ border: none; background: #e5e7eb; padding: 0.5rem 0.9rem; border-radius: 999px; cursor: pointer; font-size: 0.95rem; transition: background 0.2s ease; }}
+              .tab-button.active {{ background: #2563eb; color: #fff; }}
+              .tab-content {{ display: none; gap: 1rem; }}
+              .tab-content.active {{ display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 1.5rem; }}
+              .card {{ background: #fff; border-radius: 1rem; padding: 1.2rem 1.5rem; box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08); }}
+              .card h2 {{ margin-top: 0; font-size: 1.25rem; }}
+              .card h3 {{ margin-top: 0; font-size: 1.1rem; }}
+              .list {{ list-style: none; padding: 0; margin: 0; }}
+              .list li {{ margin-bottom: 0.5rem; }}
+              dl {{ display: grid; grid-template-columns: max-content 1fr; column-gap: 0.75rem; row-gap: 0.35rem; margin: 0; }}
+              dt {{ font-weight: 600; }}
+              footer {{ margin-top: 2rem; font-size: 0.85rem; color: #9ca3af; text-align: center; }}
+            </style>
+          </head>
+          <body>
+            <div class="container">
+              {_tabbed_html('Operations Control Center', tab_names(), tabs[0][0])}
+              <section class="card">
+                <h2>Role Summary</h2>
+                <p><strong>Current role:</strong> {state.role}</p>
+                <p><strong>{state.bot_summary()}</strong></p>
+                <p class="muted">Switch roles and interact with bots in the full NiceGUI build.</p>
+              </section>
+              {content}
+              <footer>Stub renderer active. Install NiceGUI for the interactive experience.</footer>
+            </div>
+            <script>
+              const buttons = document.querySelectorAll('.tab-button');
+              const sections = document.querySelectorAll('.tab-content');
+              buttons.forEach((button) => {{
+                button.addEventListener('click', () => {{
+                  buttons.forEach((btn) => btn.classList.remove('active'));
+                  sections.forEach((section) => section.classList.remove('active'));
+                  button.classList.add('active');
+                  const target = button.dataset.tab;
+                  const selector = '.tab-content[data-tab="' + target + '"]';
+                  const match = document.querySelector(selector);
+                  if (match) {{ match.classList.add('active'); }}
+                }});
+              }});
+            </script>
+          </body>
+        </html>
+        """
+    )

--- a/nice-gui/nicegui/testing/_simulator.py
+++ b/nice-gui/nicegui/testing/_simulator.py
@@ -88,6 +88,14 @@ class _DashboardSession:
             self.state.notification_label(notification): notification
             for notification in self.state.user.notification_preferences
         }
+        self.tab_labels = (
+            "Bots & Automations",
+            "User Profile",
+            "User Settings",
+            "Connections",
+            "AI Assistants & Billing",
+        )
+        self.active_tab = self.tab_labels[0]
 
         self.state.subscribe_activity(self._set_activity)
         self.state.subscribe_credits(self._set_credits)
@@ -100,33 +108,23 @@ class _DashboardSession:
 
         lines = [
             "Operations Control Center",
+            *self.tab_labels,
             f"Current role: {self.state.role}",
-            self._role_helper_text,
             self.state.bot_summary(),
-            "Authentication",
-            self._auth_status,
-            "Credits & Billing",
-            self._credit_summary,
-            "Profile Management",
-            "Settings",
-            "Credits used: {used} / {limit}".format(
-                used=self.state.subscription.ai_credits_used,
-                limit=self.state.plan.ai_credits_per_month,
-            ),
-            "Purchase add-on credits",
-            f"Selected package: {self.selected_amount} credits",
         ]
 
-        if self._addon_credits:
+        lines.extend(self._tab_snapshot())
+
+        if self.active_tab == "AI Assistants & Billing" and self._addon_credits:
             lines.append(f"Add-on credits: {self._addon_credits}")
 
-        lines.extend(self._bot_status_lines())
-        lines.extend(self._activity)
-
-        if self.checkout_status:
+        if self.active_tab == "AI Assistants & Billing" and self.checkout_status:
             lines.append(self.checkout_status)
-        if self.checkout_link_ready:
+        if self.active_tab == "AI Assistants & Billing" and self.checkout_link_ready:
             lines.append("Complete Purchase")
+
+        if self.active_tab == "Bots & Automations":
+            lines.extend(self._activity)
 
         return "\n".join(lines)
 
@@ -139,6 +137,7 @@ class _DashboardSession:
         return [
             "View as User",
             "View as Admin",
+            *self.tab_labels,
             *bot_controls,
             "Two-factor authentication",
             "Dice Email",
@@ -165,6 +164,80 @@ class _DashboardSession:
             lines.append(f"{bot.bot_name} automation status: {status}")
         return lines
 
+    def _tab_snapshot(self) -> List[str]:
+        if self.active_tab == "Bots & Automations":
+            return [
+                "Bot Management",
+                self._role_helper_text,
+                *self._bot_status_lines(),
+                "Recent Activity",
+            ]
+        if self.active_tab == "User Profile":
+            user = self.state.user
+            details = [
+                "Profile Management",
+                f"{user.nickname} ({user.email})" if user.email else user.nickname,
+                f"Timezone: {user.timezone}",
+                f"Preferred contact: {user.preferred_contact_method.value.replace('_', ' ').title()}",
+                "Authentication",
+                self._auth_status,
+            ]
+            details.append(
+                "Two-factor authentication is enabled"
+                if user.two_factor_enabled
+                else "Two-factor authentication is disabled"
+            )
+            details.append("Profile Configuration")
+            details.extend(self._configuration_lines(self.state.profile_sections))
+            return details
+        if self.active_tab == "User Settings":
+            lines = ["Settings", "Notifications", "Security", "Workspace Settings"]
+            lines.extend(self._configuration_lines(self.state.settings_sections))
+            return lines
+        if self.active_tab == "Connections":
+            return [
+                "Connections",
+                *self._configuration_lines(self.state.connection_sections),
+            ]
+        if self.active_tab == "AI Assistants & Billing":
+            lines = ["AI Assistant Overview"]
+            lines.extend(self._assistant_lines())
+            lines.append("Credits & Billing")
+            lines.append(self._credit_summary)
+            lines.append("Purchase add-on credits")
+            lines.append(f"Selected package: {self.selected_amount} credits")
+            return lines
+        return []
+
+    def _assistant_lines(self) -> List[str]:
+        lines: List[str] = []
+        for bot in self.state.bots:
+            lines.append(f"{bot.bot_name} ({bot.bot_model})")
+            lines.append(
+                f"Focus: {bot.function.replace('_', ' ').title()}"
+            )
+            capabilities = [cap.replace("_", " ").title() for cap in bot.capabilities]
+            if capabilities:
+                lines.append("Capabilities: " + ", ".join(capabilities))
+            settings_pairs = [
+                f"{key.replace('_', ' ').title()}: {value}"
+                for key, value in bot.settings.items()
+            ]
+            if settings_pairs:
+                lines.extend(settings_pairs)
+            status = "Active" if self.state.bot_controller.get_status(bot.bot_name) else "Paused"
+            lines.append(f"Status: {status}")
+        return lines
+
+    def _configuration_lines(self, sections) -> List[str]:
+        lines: List[str] = []
+        for section in sections:
+            lines.append(section.title)
+            for key, value in section.items:
+                rendered_value = value if value else "Not configured"
+                lines.append(f"{key}: {rendered_value}")
+        return lines
+
     # ------------------------------------------------------------------
     def handle_click(self, label: str) -> None:
         if label == "View as Admin":
@@ -182,6 +255,9 @@ class _DashboardSession:
             )
             self._auth_inputs["Dice Email"] = ""
             self._auth_inputs["Password"] = ""
+            return
+        if label in self.tab_labels:
+            self.active_tab = label
             return
         if label == "Create checkout session":
             session_id, _url = self.state.create_checkout_session(self.selected_amount)

--- a/nice-gui/tests/test_bot_interface.py
+++ b/nice-gui/tests/test_bot_interface.py
@@ -9,6 +9,7 @@ def test_admin_can_toggle_bots(user: User) -> None:
     """Administrators can activate automations and see usage updates."""
 
     user.open("/")
+    user.should_see("Bots & Automations")
     user.should_see("Operations Control Center")
     user.should_see("Current role: User")
     user.should_see("Bot controls are locked while in user mode.")
@@ -20,13 +21,23 @@ def test_admin_can_toggle_bots(user: User) -> None:
     user.find("Toggle Announcements automation").click()
     user.should_see("Announcements automation status: Active")
     user.should_see("Active automations: 1 of 3")
-    user.should_see("Credits used: 200 / 320")
     user.should_see("Announcements automation activated")
 
+    user.find("AI Assistants & Billing").click()
+    user.should_see("Credits & Billing")
+    user.should_see("Credits used: 200 / 320")
+
+    user.find("Connections").click()
+    user.should_see("DISCORD_BOT_TOKEN")
+    user.should_see("Connections")
+
+    user.find("Bots & Automations").click()
     user.find("Toggle Announcements automation").click()
     user.should_see("Announcements automation status: Paused")
-    user.should_see("Credits used: 160 / 320")
     user.should_see("Announcements automation paused")
+
+    user.find("AI Assistants & Billing").click()
+    user.should_see("Credits used: 160 / 320")
 
 
 def test_user_mode_keeps_automations_locked(user: User) -> None:
@@ -55,12 +66,14 @@ def test_profile_settings_updates_log_activity(user: User) -> None:
     """Profile settings interactions appear in the activity log."""
 
     user.open("/")
-    user.should_see("Profile Management")
+    user.find("User Settings").click()
+    user.should_see("Workspace Settings")
 
     user.find("Security alerts").click()
-    user.should_see("Security alerts notifications disabled")
-
     user.find("Two-factor authentication").click()
+
+    user.find("Bots & Automations").click()
+    user.should_see("Security alerts notifications disabled")
     user.should_see("Two-factor authentication disabled")
 
 
@@ -68,6 +81,7 @@ def test_local_login_updates_authentication_status(user: User) -> None:
     """Dice login form authenticates the dashboard session."""
 
     user.open("/")
+    user.find("User Profile").click()
     user.should_see("Authentication")
 
     user.find("Log out").click()
@@ -85,6 +99,7 @@ def test_credit_purchase_flow_adds_addon_credits(user: User) -> None:
     """Simulated checkout allocates add-on credits."""
 
     user.open("/")
+    user.find("AI Assistants & Billing").click()
     user.should_see("Credits & Billing")
 
     user.find("25 Credits ($25)").click()


### PR DESCRIPTION
## Summary
- add a reusable configuration section component and demo data describing profile, settings, and integration credentials
- reorganize the dashboard into User Profile, User Settings, Connections, and AI tabs while surfacing the new configuration cards
- extend dashboard state, simulator, and tests to exercise the new tab structure and ensure credentials appear in the Connections view

## Testing
- pytest nice-gui/tests/test_bot_interface.py

------
https://chatgpt.com/codex/tasks/task_e_68e3f8392e248329920642122587d856